### PR TITLE
Implement typed event bus

### DIFF
--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -1,0 +1,34 @@
+export type EventBus<Events extends Record<string, unknown>> = {
+  subscribe<E extends keyof Events>(
+    event: E,
+    handler: (payload: Events[E]) => void,
+  ): void;
+  unsubscribe<E extends keyof Events>(
+    event: E,
+    handler: (payload: Events[E]) => void,
+  ): void;
+  publish<E extends keyof Events>(event: E, payload: Events[E]): void;
+};
+
+export const createEventBus = <Events extends Record<string, unknown>>(): EventBus<Events> => {
+  const handlers: { [K in keyof Events]?: Array<(payload: Events[K]) => void> } = {};
+
+  return {
+    subscribe(event, handler) {
+      const list = handlers[event] ?? [];
+      handlers[event] = [...list, handler];
+    },
+    unsubscribe(event, handler) {
+      const list = handlers[event];
+      if (!list) return;
+      handlers[event] = list.filter((h) => h !== handler);
+    },
+    publish(event, payload) {
+      const list = handlers[event];
+      if (!list) return;
+      for (const handler of list) {
+        handler(payload);
+      }
+    },
+  };
+};

--- a/tests/unit/event-bus.test.ts
+++ b/tests/unit/event-bus.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import { createEventBus } from '../../src/core/event-bus.js';
+
+type TestEvents = {
+  foo: { value: number };
+};
+
+describe('event bus', () => {
+  it('publishes events to subscribers', () => {
+    const bus = createEventBus<TestEvents>();
+    const handler = jest.fn();
+    bus.subscribe('foo', handler);
+    bus.publish('foo', { value: 42 });
+
+    expect(handler).toHaveBeenCalledWith({ value: 42 });
+  });
+
+  it('does not call unsubscribed handlers', () => {
+    const bus = createEventBus<TestEvents>();
+    const handler = jest.fn();
+    bus.subscribe('foo', handler);
+    bus.unsubscribe('foo', handler);
+    bus.publish('foo', { value: 1 });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- create `EventBus` with typed publish/subscribe support
- add unit tests for the event bus behavior

## Testing
- `npx jest tests/unit/event-bus.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_685b76d1b7c48322a155c39e803bcd27