### PR TITLE
Implement plugin manager

### DIFF
--- a/src/core/plugin-manager.ts
+++ b/src/core/plugin-manager.ts
@@ -1,0 +1,86 @@
+import fs from 'fs/promises';
+import { parse as parseJson5 } from 'json5';
+import path from 'path';
+import { type AppConfig, readConfig, writeConfig } from './config.js';
+import type { EventBus } from './event-bus.js';
+
+export type PluginManifest = {
+  id: string;
+  main: string;
+  configDefaults?: Record<string, unknown>;
+};
+
+export type LoadedPlugin = {
+  manifest: PluginManifest;
+  module: {
+    init?: (options: { config: unknown; bus: EventBus<Record<string, unknown>> }) => Promise<void> | void;
+    stop?: () => Promise<void> | void;
+  };
+};
+
+export type PluginManagerOptions = {
+  pluginsPath: string;
+  configPath: string;
+  bus: EventBus<Record<string, unknown>>;
+};
+
+export const createPluginManager = (opts: PluginManagerOptions) => {
+  const loaded: Record<string, LoadedPlugin> = {};
+  let config: AppConfig = {};
+
+  const readManifest = async (file: string): Promise<PluginManifest> => {
+    const text = await fs.readFile(file, 'utf8');
+    return parseJson5(text) as PluginManifest;
+  };
+
+  const loadPlugins = async () => {
+    try {
+      config = await readConfig(opts.configPath);
+    } catch {
+      config = {};
+    }
+
+    const entries = await fs.readdir(opts.pluginsPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const manifestPath = path.join(opts.pluginsPath, entry.name, 'plugin.json5');
+      try {
+        const manifest = await readManifest(manifestPath);
+        const modPath = path.join(opts.pluginsPath, entry.name, manifest.main);
+        const mod = (await import(modPath)) as LoadedPlugin['module'];
+        loaded[manifest.id] = { manifest, module: mod };
+        if (!config.plugins) config.plugins = {} as unknown as AppConfig['plugins'];
+        if (!(config.plugins as any)[manifest.id]) {
+          (config.plugins as any)[manifest.id] = manifest.configDefaults ?? {};
+        }
+      } catch {
+        // skip invalid plugins
+      }
+    }
+    await writeConfig(opts.configPath, config);
+  };
+
+  const initPlugins = async () => {
+    for (const p of Object.values(loaded)) {
+      await p.module.init?.({ config: (config.plugins as any)[p.manifest.id], bus: opts.bus });
+    }
+  };
+
+  const stopPlugins = async () => {
+    for (const p of Object.values(loaded)) {
+      await p.module.stop?.();
+    }
+  };
+
+  const getPluginConfig = (id: string): unknown => {
+    return (config.plugins as any)?.[id];
+  };
+
+  const updatePluginConfig = async (id: string, cfg: unknown) => {
+    if (!config.plugins) config.plugins = {} as any;
+    (config.plugins as any)[id] = cfg;
+    await writeConfig(opts.configPath, config);
+  };
+
+  return { loadPlugins, initPlugins, stopPlugins, getPluginConfig, updatePluginConfig };
+};

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -37,10 +37,10 @@
     - [x] Merge plugin default settings on first run.
     - [x] Watch for configuration changes and notify plugins via event bus.
 
-  - [ ] 2.2 Plugin Manager (`src/core/plugin-manager.ts`)
-    - [ ] Load each plugin’s `plugin.json5` manifest and main module.
-    - [ ] Provide lifecycle hooks to initialize and stop plugins.
-    - [ ] Expose helper to retrieve and update plugin configuration.
+  - [x] 2.2 Plugin Manager (`src/core/plugin-manager.ts`)
+    - [x] Load each plugin’s `plugin.json5` manifest and main module.
+    - [x] Provide lifecycle hooks to initialize and stop plugins.
+    - [x] Expose helper to retrieve and update plugin configuration.
   - [x] 2.3 Logger (`src/core/logger.ts`)
     - [x] Create timestamped log entries with plugin identifiers.
     - [x] Support info, warning, and error levels written to console and file.

--- a/tests/unit/plugin-manager.test.ts
+++ b/tests/unit/plugin-manager.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { createPluginManager } from '../../src/core/plugin-manager.js';
+import { createEventBus } from '../../src/core/event-bus.js';
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+const pluginsDir = path.join(fixturesDir, 'plugins');
+const configPath = path.join(fixturesDir, 'app-config.json5');
+
+beforeEach(async () => {
+  await fs.rm(fixturesDir, { recursive: true, force: true });
+  await fs.mkdir(path.join(pluginsDir, 'simple'), { recursive: true });
+  await fs.writeFile(
+    path.join(pluginsDir, 'simple', 'plugin.json5'),
+    '{id:"simple", main:"./index.js", configDefaults:{enabled:true}}',
+    'utf8',
+  );
+  await fs.writeFile(
+    path.join(pluginsDir, 'simple', 'index.js'),
+    'export const init = async () => {}; export const stop = async () => {};',
+    'utf8',
+  );
+  await fs.writeFile(configPath, '{}', 'utf8');
+});
+
+afterEach(async () => {
+  await fs.rm(fixturesDir, { recursive: true, force: true });
+});
+
+describe('plugin manager', () => {
+  it('loads manifests and initializes plugins', async () => {
+    const bus = createEventBus<Record<string, unknown>>();
+    const manager = createPluginManager({
+      pluginsPath: pluginsDir,
+      configPath,
+      bus,
+    });
+
+    await manager.loadPlugins();
+    await manager.initPlugins();
+
+    expect(manager.getPluginConfig('simple')).toEqual({ enabled: true });
+  });
+
+  it('updates plugin configuration', async () => {
+    const bus = createEventBus<Record<string, unknown>>();
+    const manager = createPluginManager({ pluginsPath: pluginsDir, configPath, bus });
+    await manager.loadPlugins();
+    await manager.updatePluginConfig('simple', { enabled: false });
+    expect(manager.getPluginConfig('simple')).toEqual({ enabled: false });
+  });
+});


### PR DESCRIPTION
## Summary
- add plugin manager to load plugin manifests
- include lifecycle and config helpers
- create plugin manager unit tests
- check off plugin manager tasks

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Missing script)*
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b7d506ae083228139a58f3680db31