### PR TITLE
Fix logger test and reopen core module tasks

### DIFF
--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -16,12 +16,14 @@
 - `config/app-config.json5` - Main application configuration file.
 - `tests/core/**/*.ts` - Jest unit tests for core modules and components.
 - `tests/e2e/**/*.spec.ts` - Playwright end-to-end tests for plugin flows.
+- `tasks/tasks-redoprompt.md` - Task list for project management.
 
 ### Notes
 
 - Follow Test-Driven Development: write failing tests before implementation.
 - Use TypeScript in strict mode for all source files.
 - Apply the color palette from `prompts/style..css.md` and the Nunito Sans font for UI components.
+- Mark a task complete only after test coverage verifies the behavior.
 
 ## Tasks
 
@@ -32,21 +34,21 @@
 
 - [ ] 2.0 Core Modules Implementation
 
-  - [x] 2.1 Configuration Manager (`src/core/config.ts`)
-    - [x] Read and write `config/app-config.json5` using JSON5 parser.
-    - [x] Merge plugin default settings on first run.
-    - [x] Watch for configuration changes and notify plugins via event bus.
+  - [ ] 2.1 Configuration Manager (`src/core/config.ts`)
+    - [ ] Read and write `config/app-config.json5` using JSON5 parser.
+    - [ ] Merge plugin default settings on first run.
+    - [ ] Watch for configuration changes and notify plugins via event bus.
 
-  - [x] 2.2 Plugin Manager (`src/core/plugin-manager.ts`)
-    - [x] Load each plugin’s `plugin.json5` manifest and main module.
-    - [x] Provide lifecycle hooks to initialize and stop plugins.
-    - [x] Expose helper to retrieve and update plugin configuration.
-  - [x] 2.3 Logger (`src/core/logger.ts`)
-    - [x] Create timestamped log entries with plugin identifiers.
-    - [x] Support info, warning, and error levels written to console and file.
-  - [x] 2.4 Event Bus (`src/core/event-bus.ts`)
-    - [x] Implement publish/subscribe for core and plugins.
-    - [x] Ensure events are strongly typed and support payloads.
+  - [ ] 2.2 Plugin Manager (`src/core/plugin-manager.ts`)
+    - [ ] Load each plugin’s `plugin.json5` manifest and main module.
+    - [ ] Provide lifecycle hooks to initialize and stop plugins.
+    - [ ] Expose helper to retrieve and update plugin configuration.
+  - [ ] 2.3 Logger (`src/core/logger.ts`)
+    - [ ] Create timestamped log entries with plugin identifiers.
+    - [ ] Support info, warning, and error levels written to console and file.
+  - [ ] 2.4 Event Bus (`src/core/event-bus.ts`)
+    - [ ] Implement publish/subscribe for core and plugins.
+    - [ ] Ensure events are strongly typed and support payloads.
 
 - [ ] 3.0 Built-in Components
   - [ ] 3.1 FileScanner Component

--- a/tests/core/logger.test.ts
+++ b/tests/core/logger.test.ts
@@ -1,3 +1,20 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import fs from 'fs/promises';
+import path from 'path';
+
+import { createLogger } from '../../src/core/logger.js';
+
+const logFile = path.join(__dirname, 'test.log');
+
+beforeEach(async () => {
+  await fs.writeFile(logFile, '', 'utf8');
+});
+
+afterEach(async () => {
+  await fs.rm(logFile, { force: true });
+  jest.restoreAllMocks();
+});
+
 describe('logger', () => {
   it('writes formatted entries to console and file', async () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- clarify that tasks require passing tests before completion
- reopen all core module tasks until tests pass
- restore imports in `logger.test.ts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b83057fe48322b638b58e2dd7466b