### PR TITLE
Integrate crawler helper

### DIFF
--- a/src/core/crawler.d.ts
+++ b/src/core/crawler.d.ts
@@ -1,0 +1,21 @@
+export type CrawlNode = {
+  name: string;
+  type: 'directory' | 'file' | 'error';
+  path: string;
+  error?: string;
+  children: CrawlNode[];
+};
+
+export type CrawlOptions = {
+  folderRegex?: string;
+  folderFilterType?: 'include' | 'exclude';
+  fileRegex?: string;
+  fileFilterType?: 'include' | 'exclude';
+  maxDepth?: number | null;
+};
+
+export function crawlDirectory(
+  dirPath: string,
+  options?: CrawlOptions,
+  currentDepth?: number,
+): Promise<CrawlNode | null>;

--- a/src/core/file-crawler.ts
+++ b/src/core/file-crawler.ts
@@ -1,0 +1,15 @@
+import { crawlDirectory } from './crawler.js';
+import type { FileNode } from '../ui/components/FileScanner.js';
+
+const toFileNode = (node: any): FileNode => ({
+  name: node.name,
+  path: node.path,
+  isDirectory: node.type === 'directory',
+  children: node.children?.map(toFileNode),
+});
+
+export const getFileTree = async (dir: string): Promise<FileNode[]> => {
+  const root = await crawlDirectory(dir);
+  if (!root) return [];
+  return root.children.map(toFileNode);
+};

--- a/src/core/utility.ts
+++ b/src/core/utility.ts
@@ -1,0 +1,6 @@
+import path from 'path';
+
+export const sanitizeAbsolutePath = (p: string): string => {
+  if (!p) throw new Error('Path is required');
+  return path.normalize(path.resolve(p));
+};

--- a/tests/core/file-crawler.test.ts
+++ b/tests/core/file-crawler.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { getFileTree } from '../../src/core/file-crawler.js';
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const tmpDir = path.join(__dirname, 'tree');
+
+beforeEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  await fs.mkdir(path.join(tmpDir, 'sub'), { recursive: true });
+  await fs.writeFile(path.join(tmpDir, 'sub', 'a.txt'), '');
+  await fs.writeFile(path.join(tmpDir, 'b.txt'), '');
+});
+
+describe('getFileTree', () => {
+  it('converts crawl output to FileNode list', async () => {
+    const result = await getFileTree(tmpDir);
+    expect(result.length).toBe(2);
+    const names = result.map((n) => n.name).sort();
+    expect(names).toEqual(['b.txt', 'sub']);
+  });
+});


### PR DESCRIPTION
## Summary
- add utility helper for sanitizing paths
- expose file crawling via `getFileTree`
- provide TypeScript definitions for crawler
- test file tree generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf4c858808322a9d078a3f8cfe02c