### PR TITLE
Implement TDD step for FileScanner dialog

### DIFF
--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -58,7 +58,7 @@
   - [ ] 3.1 FileScanner Component
     - [x] Display file tree with checkboxes for files and folders.
     - [x] Provide search box for filtering tree results.
-    - [ ] Write failing test for dialog to select root folder and remember path.
+    - [x] Write failing test for dialog to select root folder and remember path.
     - [ ] Implement dialog to select root folder and remember path.
     - [ ] Write failing test for preset dropdown and filter name field to save presets.
     - [ ] Implement preset dropdown and filter name field to save presets.

--- a/tests/ui/components/FileScanner.test.tsx
+++ b/tests/ui/components/FileScanner.test.tsx
@@ -37,4 +37,16 @@ describe('FileScanner component', () => {
     expect(screen.queryByLabelText('src')).not.toBeInTheDocument();
     expect(screen.getByLabelText('README.md')).toBeInTheDocument();
   });
+
+  it('opens dialog to select root folder and remembers path', async () => {
+    const selectRootFolder = jest.fn().mockResolvedValue('/workspace');
+    render(<FileScanner tree={[]} selectRootFolder={selectRootFolder} />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /select root folder/i }),
+    );
+
+    expect(selectRootFolder).toHaveBeenCalled();
+    expect(await screen.findByText('/workspace')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- mark task complete for the FileScanner root folder dialog test
- add failing test for selecting a root folder path

## Testing
- `npx --no-install jest --runInBand` *(fails: Property 'selectRootFolder' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685c76f25bc08322b7c8ddd25ccbb6a5