### PR TITLE
Implement FileScanner root folder selection

### DIFF
--- a/src/ui/components/FileScanner.tsx
+++ b/src/ui/components/FileScanner.tsx
@@ -12,9 +12,13 @@ export type FileNode = {
 
 export type FileScannerProps = {
   tree: FileNode[];
+  selectRootFolder?: () => Promise<string>;
 };
 
-export const FileScanner: React.FC<FileScannerProps> = ({ tree }) => {
+export const FileScanner: React.FC<FileScannerProps> = ({
+  tree,
+  selectRootFolder,
+}) => {
 
   const [query, setQuery] = useState('');
 
@@ -32,6 +36,8 @@ export const FileScanner: React.FC<FileScannerProps> = ({ tree }) => {
       })
       .filter(Boolean) as FileNode[];
   };
+
+  const [rootPath, setRootPath] = useState<string | undefined>();
 
   const filtered = filterTree(tree);
 
@@ -55,6 +61,18 @@ export const FileScanner: React.FC<FileScannerProps> = ({ tree }) => {
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
+      {selectRootFolder && (
+        <button
+          type="button"
+          onClick={async () => {
+            const path = await selectRootFolder();
+            setRootPath(path);
+          }}
+        >
+          Select Root Folder
+        </button>
+      )}
+      {rootPath && <div>{rootPath}</div>}
       <ul className="file-scanner">{filtered.map(renderNode)}</ul>
     </div>
   );

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -58,8 +58,8 @@
   - [ ] 3.1 FileScanner Component
     - [x] Display file tree with checkboxes for files and folders.
     - [x] Provide search box for filtering tree results.
-    - [ ] Write failing test for dialog to select root folder and remember path.
-    - [ ] Implement dialog to select root folder and remember path.
+    - [x] Write failing test for dialog to select root folder and remember path.
+    - [x] Implement dialog to select root folder and remember path.
     - [ ] Write failing test for preset dropdown and filter name field to save presets.
     - [ ] Implement preset dropdown and filter name field to save presets.
     - [ ] Write failing test for include/exclude regex mode selectors.

--- a/tests/ui/components/FileScanner.test.tsx
+++ b/tests/ui/components/FileScanner.test.tsx
@@ -37,4 +37,16 @@ describe('FileScanner component', () => {
     expect(screen.queryByLabelText('src')).not.toBeInTheDocument();
     expect(screen.getByLabelText('README.md')).toBeInTheDocument();
   });
+
+  it('opens dialog to select root folder and remembers path', async () => {
+    const selectRootFolder = jest.fn().mockResolvedValue('/workspace');
+    render(<FileScanner tree={[]} selectRootFolder={selectRootFolder} />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /select root folder/i }),
+    );
+
+    expect(selectRootFolder).toHaveBeenCalled();
+    expect(await screen.findByText('/workspace')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- mark task complete for selecting root folder dialog
- enable selecting a root path in FileScanner

## Testing
- `npm install`
- `./node_modules/.bin/jest --runInBand`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685c76f25bc08322b7c8ddd25ccbb6a5