### PR TITLE
Add failing test for FileScanner preset saving

### DIFF
--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -59,12 +59,8 @@
     - [x] Display file tree with checkboxes for files and folders.
     - [x] Provide search box for filtering tree results.
     - [x] Write failing test for dialog to select root folder and remember path.
-<<<<<<< ins7rd-codex/process-task-list-as-instructed
     - [x] Implement dialog to select root folder and remember path.
-=======
-    - [ ] Implement dialog to select root folder and remember path.
->>>>>>> main
-    - [ ] Write failing test for preset dropdown and filter name field to save presets.
+    - [x] Write failing test for preset dropdown and filter name field to save presets.
     - [ ] Implement preset dropdown and filter name field to save presets.
     - [ ] Write failing test for include/exclude regex mode selectors.
     - [ ] Implement include/exclude regex mode selectors for folders and files.

--- a/tests/ui/components/FileScanner.test.tsx
+++ b/tests/ui/components/FileScanner.test.tsx
@@ -49,4 +49,22 @@ describe('FileScanner component', () => {
     expect(selectRootFolder).toHaveBeenCalled();
     expect(await screen.findByText('/workspace')).toBeInTheDocument();
   });
+
+  it('saves a filter preset with name and shows in dropdown', async () => {
+    const onSavePreset = jest.fn();
+    render(
+      <FileScanner tree={[]} presets={[]} onSavePreset={onSavePreset} />,
+    );
+
+    await userEvent.type(
+      screen.getByPlaceholderText(/filter name/i),
+      'My Filter',
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /save preset/i }),
+    );
+
+    expect(onSavePreset).toHaveBeenCalledWith('My Filter');
+    expect(screen.getByRole('combobox')).toHaveTextContent('My Filter');
+  });
 });


### PR DESCRIPTION
## Summary
- mark task for root folder dialog complete and add failing preset test to tasks
- add failing test for saving filter presets in FileScanner

## Testing
- `npm test --silent` *(fails: Property 'presets' does not exist on type 'FileScannerProps')*

------
https://chatgpt.com/codex/tasks/task_e_685c7fbe9ec083229d64dc9830ca7f17