### PR TITLE
Implement FileScanner preset saving

### DIFF
--- a/src/ui/components/FileScanner.tsx
+++ b/src/ui/components/FileScanner.tsx
@@ -13,11 +13,15 @@ export type FileNode = {
 export type FileScannerProps = {
   tree: FileNode[];
   selectRootFolder?: () => Promise<string>;
+  presets?: string[];
+  onSavePreset?: (name: string) => void;
 };
 
 export const FileScanner: React.FC<FileScannerProps> = ({
   tree,
   selectRootFolder,
+  presets = [],
+  onSavePreset,
 }) => {
 
   const [query, setQuery] = useState('');
@@ -38,6 +42,9 @@ export const FileScanner: React.FC<FileScannerProps> = ({
   };
 
   const [rootPath, setRootPath] = useState<string | undefined>();
+  const [presetName, setPresetName] = useState('');
+  const [presetList, setPresetList] = useState<string[]>(presets);
+  const [selectedPreset, setSelectedPreset] = useState<string | undefined>();
 
   const filtered = filterTree(tree);
 
@@ -73,6 +80,34 @@ export const FileScanner: React.FC<FileScannerProps> = ({
         </button>
       )}
       {rootPath && <div>{rootPath}</div>}
+      <select
+        value={selectedPreset}
+        onChange={(e) => setSelectedPreset(e.target.value)}
+        aria-label="Preset Selector"
+      >
+        {presetList.map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      <input
+        placeholder="Filter Name"
+        value={presetName}
+        onChange={(e) => setPresetName(e.target.value)}
+      />
+      <button
+        type="button"
+        onClick={() => {
+          if (!presetName) return;
+          setPresetList([...presetList, presetName]);
+          setSelectedPreset(presetName);
+          onSavePreset?.(presetName);
+          setPresetName('');
+        }}
+      >
+        Save Preset
+      </button>
       <ul className="file-scanner">{filtered.map(renderNode)}</ul>
     </div>
   );

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -61,7 +61,7 @@
     - [x] Write failing test for dialog to select root folder and remember path.
     - [x] Implement dialog to select root folder and remember path.
     - [x] Write failing test for preset dropdown and filter name field to save presets.
-    - [ ] Implement preset dropdown and filter name field to save presets.
+    - [x] Implement preset dropdown and filter name field to save presets.
     - [ ] Write failing test for include/exclude regex mode selectors.
     - [ ] Implement include/exclude regex mode selectors for folders and files.
     - [ ] Write failing test for max depth setting for recursive scans.


### PR DESCRIPTION
## Summary
- add preset dropdown and filter name field to FileScanner
- mark preset saving task complete in task list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c8a9e82dc832283e2c00c7a70b629