### PR TITLE
Add failing test for regex mode selectors

### DIFF
--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -62,7 +62,7 @@
     - [x] Implement dialog to select root folder and remember path.
     - [x] Write failing test for preset dropdown and filter name field to save presets.
     - [x] Implement preset dropdown and filter name field to save presets.
-    - [ ] Write failing test for include/exclude regex mode selectors.
+    - [x] Write failing test for include/exclude regex mode selectors.
     - [ ] Implement include/exclude regex mode selectors for folders and files.
     - [ ] Write failing test for max depth setting for recursive scans.
     - [ ] Implement max depth setting for recursive scans.

--- a/tests/ui/components/FileScanner.test.tsx
+++ b/tests/ui/components/FileScanner.test.tsx
@@ -67,4 +67,24 @@ describe('FileScanner component', () => {
     expect(onSavePreset).toHaveBeenCalledWith('My Filter');
     expect(screen.getByRole('combobox')).toHaveTextContent('My Filter');
   });
+
+  it('allows toggling include/exclude regex modes for folders and files', async () => {
+    render(<FileScanner tree={[]} />);
+
+    const includeFolders = screen.getByRole('radio', { name: /include folders/i });
+    const excludeFolders = screen.getByRole('radio', { name: /exclude folders/i });
+    const includeFiles = screen.getByRole('radio', { name: /include files/i });
+    const excludeFiles = screen.getByRole('radio', { name: /exclude files/i });
+
+    expect(includeFolders).toBeInTheDocument();
+    expect(excludeFolders).toBeInTheDocument();
+    expect(includeFiles).toBeInTheDocument();
+    expect(excludeFiles).toBeInTheDocument();
+
+    await userEvent.click(excludeFolders);
+    expect(excludeFolders).toBeChecked();
+
+    await userEvent.click(excludeFiles);
+    expect(excludeFiles).toBeChecked();
+  });
 });


### PR DESCRIPTION
## Summary
- mark failing test subtask complete in tasks list
- add failing test for include/exclude regex mode selectors

## Testing
- `npx jest --runInBand` *(fails: jest package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685cba23cb7c8322998ad7f65caa3e37