### PR TITLE
Implement Task 3.1.9 failing test

### DIFF
--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -67,7 +67,7 @@
     - [x] 3.1.6 Implement preset dropdown and filter name field to save presets.
     - [x] 3.1.7 Write failing test for include/exclude regex mode selectors.
     - [x] 3.1.8 Implement include/exclude regex mode selectors for folders and files.
-    - [ ] 3.1.9 Write failing test for max depth setting for recursive scans.
+    - [x] 3.1.9 Write failing test for max depth setting for recursive scans.
     - [ ] 3.1.10 Implement max depth setting for recursive scans.
     - [ ] 3.1.11 Write failing test for Apply filters button to rescan with current settings.
     - [ ] 3.1.12 Implement Apply filters button to rescan with current settings.

--- a/tests/ui/components/FileScanner.test.tsx
+++ b/tests/ui/components/FileScanner.test.tsx
@@ -87,4 +87,33 @@ describe('FileScanner component', () => {
     await userEvent.click(excludeFiles);
     expect(excludeFiles).toBeChecked();
   });
+
+  it('limits displayed depth based on max depth setting', async () => {
+    const tree: FileNode[] = [
+      {
+        name: 'folder',
+        path: '/folder',
+        isDirectory: true,
+        children: [
+          {
+            name: 'sub',
+            path: '/folder/sub',
+            isDirectory: true,
+            children: [
+              { name: 'deep.txt', path: '/folder/sub/deep.txt', isDirectory: false },
+            ],
+          },
+        ],
+      },
+    ];
+
+    render(<FileScanner tree={tree} />);
+
+    const depthInput = screen.getByLabelText(/max depth/i);
+    await userEvent.clear(depthInput);
+    await userEvent.type(depthInput, '1');
+
+    expect(screen.getByLabelText('sub')).toBeInTheDocument();
+    expect(screen.queryByLabelText('deep.txt')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- mark subtask 3.1.9 as complete
- add failing test for max depth setting in FileScanner component

## Testing
- `npm install`
- `npm test --silent` *(fails: unable to find max depth input)*

------
https://chatgpt.com/codex/tasks/task_e_685cbfc66ee48322a037ede701b5230f