### PR TITLE
Implement Apply Filters rescan feature

### DIFF
--- a/src/ui/components/FileScanner.tsx
+++ b/src/ui/components/FileScanner.tsx
@@ -15,6 +15,12 @@ export type FileScannerProps = {
   selectRootFolder?: () => Promise<string>;
   presets?: string[];
   onSavePreset?: (name: string) => void;
+  onApplyFilters?: (settings: {
+    query: string;
+    maxDepth?: number;
+    folderRegexMode: 'include' | 'exclude';
+    fileRegexMode: 'include' | 'exclude';
+  }) => void;
 };
 
 export const FileScanner: React.FC<FileScannerProps> = ({
@@ -22,6 +28,7 @@ export const FileScanner: React.FC<FileScannerProps> = ({
   selectRootFolder,
   presets = [],
   onSavePreset,
+  onApplyFilters,
 }) => {
 
   const [query, setQuery] = useState('');
@@ -180,6 +187,19 @@ export const FileScanner: React.FC<FileScannerProps> = ({
           }}
         />
       </label>
+      <button
+        type="button"
+        onClick={() =>
+          onApplyFilters?.({
+            query,
+            maxDepth,
+            folderRegexMode,
+            fileRegexMode,
+          })
+        }
+      >
+        Apply Filters
+      </button>
       <ul className="file-scanner">{filtered.map(renderNode)}</ul>
     </div>
   );

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -69,8 +69,8 @@
     - [x] 3.1.8 Implement include/exclude regex mode selectors for folders and files.
     - [x] 3.1.9 Write failing test for max depth setting for recursive scans.
     - [x] 3.1.10 Implement max depth setting for recursive scans.
-    - [ ] 3.1.11 Write failing test for Apply filters button to rescan with current settings.
-    - [ ] 3.1.12 Implement Apply filters button to rescan with current settings.
+    - [x] 3.1.11 Write failing test for Apply filters button to rescan with current settings.
+    - [x] 3.1.12 Implement Apply filters button to rescan with current settings.
     - [ ] 3.1.13 Write failing test for Save Filter and Delete Filter actions.
     - [ ] 3.1.14 Implement Save Filter and Delete Filter actions for managing presets.
 

--- a/tests/ui/components/FileScanner.test.tsx
+++ b/tests/ui/components/FileScanner.test.tsx
@@ -116,4 +116,15 @@ describe('FileScanner component', () => {
     expect(screen.getByLabelText('sub')).toBeInTheDocument();
     expect(screen.queryByLabelText('deep.txt')).not.toBeInTheDocument();
   });
+  it("rescans when clicking Apply Filters", async () => {
+    const onApply = jest.fn();
+    render(<FileScanner tree={[]} onApplyFilters={onApply} />);
+    await userEvent.type(screen.getByPlaceholderText("Search"), "foo");
+    const depthInput = screen.getByLabelText(/max depth/i);
+    await userEvent.clear(depthInput);
+    await userEvent.type(depthInput, "2");
+    await userEvent.click(screen.getByRole("button", { name: /apply filters/i }));
+    expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ query: "foo", maxDepth: 2 }));
+  });
+
 });


### PR DESCRIPTION
## Summary
- add failing test for Apply Filters button
- implement Apply Filters button in `FileScanner`
- update task list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cc1ccccb083228c1bb7f430a2b4d2