### PR TITLE
Implement filter preset management

### DIFF
--- a/src/ui/components/FileScanner.tsx
+++ b/src/ui/components/FileScanner.tsx
@@ -15,6 +15,7 @@ export type FileScannerProps = {
   selectRootFolder?: () => Promise<string>;
   presets?: string[];
   onSavePreset?: (name: string) => void;
+  onDeletePreset?: (name: string) => void;
   onApplyFilters?: (settings: {
     query: string;
     maxDepth?: number;
@@ -28,6 +29,7 @@ export const FileScanner: React.FC<FileScannerProps> = ({
   selectRootFolder,
   presets = [],
   onSavePreset,
+  onDeletePreset,
   onApplyFilters,
 }) => {
 
@@ -128,6 +130,28 @@ export const FileScanner: React.FC<FileScannerProps> = ({
         }}
       >
         Save Preset
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          if (!selectedPreset) return;
+          onSavePreset?.(selectedPreset);
+        }}
+        disabled={!selectedPreset}
+      >
+        Save Filter
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          if (!selectedPreset) return;
+          setPresetList(presetList.filter((p) => p !== selectedPreset));
+          onDeletePreset?.(selectedPreset);
+          setSelectedPreset(undefined);
+        }}
+        disabled={!selectedPreset}
+      >
+        Delete Filter
       </button>
       <fieldset>
         <legend>Folder Regex Mode</legend>

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -71,8 +71,8 @@
     - [x] 3.1.10 Implement max depth setting for recursive scans.
     - [x] 3.1.11 Write failing test for Apply filters button to rescan with current settings.
     - [x] 3.1.12 Implement Apply filters button to rescan with current settings.
-    - [ ] 3.1.13 Write failing test for Save Filter and Delete Filter actions.
-    - [ ] 3.1.14 Implement Save Filter and Delete Filter actions for managing presets.
+    - [x] 3.1.13 Write failing test for Save Filter and Delete Filter actions.
+    - [x] 3.1.14 Implement Save Filter and Delete Filter actions for managing presets.
 
   - [ ] 3.2 JsonEditor Component
     - [ ] 3.2.1 Write failing test for opening and editing JSON or JSON5 files with optional schema enforcement.

--- a/tests/ui/components/FileScanner.test.tsx
+++ b/tests/ui/components/FileScanner.test.tsx
@@ -127,4 +127,39 @@ describe('FileScanner component', () => {
     expect(onApply).toHaveBeenCalledWith(expect.objectContaining({ query: "foo", maxDepth: 2 }));
   });
 
+  it('saves current filter for selected preset', async () => {
+    const onSavePreset = jest.fn();
+    render(
+      <FileScanner tree={[]} presets={["Default"]} onSavePreset={onSavePreset} />,
+    );
+
+    await userEvent.selectOptions(
+      screen.getByLabelText('Preset Selector'),
+      'Default',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /save filter/i }));
+
+    expect(onSavePreset).toHaveBeenCalledWith('Default');
+  });
+
+  it('deletes selected preset from list', async () => {
+    const onDeletePreset = jest.fn();
+    render(
+      <FileScanner
+        tree={[]}
+        presets={["One", "Two"]}
+        onDeletePreset={onDeletePreset}
+      />,
+    );
+
+    await userEvent.selectOptions(
+      screen.getByLabelText('Preset Selector'),
+      'One',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /delete filter/i }));
+
+    expect(onDeletePreset).toHaveBeenCalledWith('One');
+    expect(screen.getByLabelText('Preset Selector')).not.toHaveTextContent('One');
+  });
+
 });


### PR DESCRIPTION
## Summary
- add failing tests for save/delete filter actions
- implement Save Filter and Delete Filter buttons for FileScanner
- update task list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685cc379dd708322b8280fc379382350