### PR TITLE
Implement JsonEditor component

### DIFF
--- a/src/ui/components/JsonEditor.css
+++ b/src/ui/components/JsonEditor.css
@@ -1,0 +1,5 @@
+textarea {
+  width: 100%;
+  font-family: 'Nunito Sans', sans-serif;
+  color: var(--tt-color-text-primary-light);
+}

--- a/src/ui/components/JsonEditor.tsx
+++ b/src/ui/components/JsonEditor.tsx
@@ -1,11 +1,46 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { parse as parseJson5 } from 'json5';
+import type { ZodType } from 'zod';
+
+import './JsonEditor.css';
 
 export type JsonEditorProps = {
   initialContent: string;
-  schema?: unknown;
+  schema?: ZodType<unknown>;
   onChange?: (content: string) => void;
 };
 
-export const JsonEditor: React.FC<JsonEditorProps> = () => {
-  return <div>JsonEditor not implemented</div>;
+export const JsonEditor: React.FC<JsonEditorProps> = ({
+  initialContent,
+  schema,
+  onChange,
+}) => {
+  const [content, setContent] = useState(initialContent);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const parsed = parseJson5(content);
+      if (schema) {
+        const result = schema.safeParse(parsed);
+        setError(result.success ? null : 'Invalid content');
+      } else {
+        setError(null);
+      }
+    } catch {
+      setError('Invalid content');
+    }
+    onChange?.(content);
+  }, [content, schema, onChange]);
+
+  return (
+    <div>
+      <textarea
+        aria-label="json-editor"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      {error && <div>{error}</div>}
+    </div>
+  );
 };

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -12,6 +12,7 @@
 - `tests/setup.ts` - Jest setup including custom matchers.
 - `tests/style-mock.js` - Stub for imported CSS modules during tests.
 - `src/ui/components/JsonEditor.tsx` - JSON5 editor with schema enforcement.
+- `src/ui/components/JsonEditor.css` - Styles for the JsonEditor component.
 - `tests/ui/components/JsonEditor.test.tsx` - Tests for JsonEditor UI behavior.
 - `src/ui/components/MercurialCommit.ts` - Commit edited files to Mercurial.
 - `plugins/script-runner/index.ts` - PowerShell script discovery and execution plugin.
@@ -77,7 +78,7 @@
 
   - [ ] 3.2 JsonEditor Component
   - [x] 3.2.1 Write failing test for opening and editing JSON or JSON5 files with optional schema enforcement.
-    - [ ] 3.2.2 Implement opening and editing JSON or JSON5 files with optional schema enforcement.
+    - [x] 3.2.2 Implement opening and editing JSON or JSON5 files with optional schema enforcement.
     - [ ] 3.2.3 Write failing test for adding and deleting entries within a file.
     - [ ] 3.2.4 Implement adding and deleting entries within a file.
     - [ ] 3.2.5 Write failing test for API allowing plugins to open a file with its schema.

--- a/tests/ui/components/JsonEditor.test.tsx
+++ b/tests/ui/components/JsonEditor.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { z } from 'zod';
 
 import { JsonEditor } from '../../../src/ui/components/JsonEditor.js';
@@ -12,8 +11,7 @@ describe('JsonEditor component', () => {
     const textbox = screen.getByRole('textbox');
     expect(textbox).toHaveValue('{"foo": "bar"}');
 
-    await userEvent.clear(textbox);
-    await userEvent.type(textbox, '{"foo": "baz"}');
+    fireEvent.change(textbox, { target: { value: '{"foo": "baz"}' } });
 
     expect(onChange).toHaveBeenLastCalledWith('{"foo": "baz"}');
   });
@@ -23,8 +21,7 @@ describe('JsonEditor component', () => {
     render(<JsonEditor initialContent='{"foo": "bar"}' schema={schema} />);
 
     const textbox = screen.getByRole('textbox');
-    await userEvent.clear(textbox);
-    await userEvent.type(textbox, '{"foo": 123}');
+    fireEvent.change(textbox, { target: { value: '{"foo": 123}' } });
 
     expect(await screen.findByText(/invalid/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- implement JsonEditor with JSON5 parsing and optional Zod schema
- add JsonEditor styles
- update tests to drive component behaviour
- mark task 3.2.2 complete

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685d40bc50a08322a75766d8f32df67f