### PR TITLE
Implement JsonEditor entry management

### DIFF
--- a/src/ui/components/JsonEditor.tsx
+++ b/src/ui/components/JsonEditor.tsx
@@ -17,10 +17,23 @@ export const JsonEditor: React.FC<JsonEditorProps> = ({
 }) => {
   const [content, setContent] = useState(initialContent);
   const [error, setError] = useState<string | null>(null);
+  const [entries, setEntries] = useState<Record<string, unknown>>({});
+
+  const stringify = (obj: Record<string, unknown>): string =>
+    JSON.stringify(obj).replace(/:/g, ': ').replace(/,/g, ', ');
 
   useEffect(() => {
     try {
       const parsed = parseJson5(content);
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        setEntries(parsed as Record<string, unknown>);
+      } else {
+        setEntries({});
+      }
       if (schema) {
         const result = schema.safeParse(parsed);
         setError(result.success ? null : 'Invalid content');
@@ -29,9 +42,32 @@ export const JsonEditor: React.FC<JsonEditorProps> = ({
       }
     } catch {
       setError('Invalid content');
+      setEntries({});
     }
     onChange?.(content);
   }, [content, schema, onChange]);
+
+  const addEntry = () => {
+    try {
+      const parsed = parseJson5(content) as Record<string, unknown>;
+      parsed.new = '';
+      const newContent = stringify(parsed);
+      setContent(newContent);
+    } catch {
+      // ignore invalid JSON when adding entry
+    }
+  };
+
+  const deleteEntry = (key: string) => {
+    try {
+      const parsed = parseJson5(content) as Record<string, unknown>;
+      delete parsed[key];
+      const newContent = stringify(parsed);
+      setContent(newContent);
+    } catch {
+      // ignore invalid JSON when deleting entry
+    }
+  };
 
   return (
     <div>
@@ -41,6 +77,10 @@ export const JsonEditor: React.FC<JsonEditorProps> = ({
         onChange={(e) => setContent(e.target.value)}
       />
       {error && <div>{error}</div>}
+      <button onClick={addEntry}>Add Entry</button>
+      {Object.keys(entries).map((key) => (
+        <button key={key} onClick={() => deleteEntry(key)}>{`Delete ${key}`}</button>
+      ))}
     </div>
   );
 };

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -80,7 +80,7 @@
     - [x] 3.2.1 Write failing test for opening and editing JSON or JSON5 files with optional schema enforcement.
     - [x] 3.2.2 Implement opening and editing JSON or JSON5 files with optional schema enforcement.
     - [x] 3.2.3 Write failing test for adding and deleting entries within a file.
-    - [ ] 3.2.4 Implement adding and deleting entries within a file.
+    - [x] 3.2.4 Implement adding and deleting entries within a file.
     - [ ] 3.2.5 Write failing test for API allowing plugins to open a file with its schema.
     - [ ] 3.2.6 Implement API allowing plugins to open a file with its schema.
     - [ ] 3.2.7 Write failing test for function to compact nested data beyond a chosen depth.

--- a/tests/ui/components/JsonEditor.test.tsx
+++ b/tests/ui/components/JsonEditor.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { z } from 'zod';
 
 import { JsonEditor } from '../../../src/ui/components/JsonEditor.js';


### PR DESCRIPTION
## Summary
- add ability to add and delete JSON entries
- ensure JsonEditor tests import userEvent
- mark task completed in task list

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685d48132ec88322b8f2123fcc9fd934