### PR TITLE
Implement test for running PowerShell scripts

### DIFF
--- a/plugins/script-runner/index.ts
+++ b/plugins/script-runner/index.ts
@@ -54,3 +54,16 @@ export const filterScripts = (scripts: Script[], query: string): Script[] => {
       s.description.toLowerCase().includes(q),
   );
 };
+
+export type ScriptStatus = 'running' | 'success' | 'error';
+
+export const runScript = (
+  script: Script,
+  params: string[],
+  onStatus: (status: ScriptStatus) => void,
+): Promise<void> => {
+  void script;
+  void params;
+  void onStatus;
+  throw new Error('not implemented');
+};

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -106,7 +106,7 @@
   - [ ] 4.1 Script Runner Plugin
     - [x] 4.1.1 Write failing test to discover PowerShell scripts and list them with filter by ID, name, or description.
     - [x] 4.1.2 Implement discovery of PowerShell scripts and list them with filter by ID, name, or description.
-    - [ ] 4.1.3 Write failing test for running scripts with default parameters and showing status indicator.
+    - [x] 4.1.3 Write failing test for running scripts with default parameters and showing status indicator.
     - [ ] 4.1.4 Implement running scripts with default parameters and showing status indicator.
     - [ ] 4.1.5 Write failing test for Customize dialog to override parameters and save defaults.
     - [ ] 4.1.6 Implement Customize dialog to override parameters and save defaults.

--- a/tests/plugins/script-runner.test.ts
+++ b/tests/plugins/script-runner.test.ts
@@ -1,7 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
-import { discoverScripts, filterScripts } from '../../plugins/script-runner/index.js';
+import child_process from 'child_process';
+import {
+  discoverScripts,
+  filterScripts,
+  runScript,
+} from '../../plugins/script-runner/index.js';
 
 describe('script runner plugin', () => {
   const tmpDir = path.join(__dirname, 'scripts');
@@ -29,5 +34,44 @@ describe('script runner plugin', () => {
 
     const filtered = filterScripts(scripts, 'deploy');
     expect(filtered).toEqual([{ id: 'deploy', name: 'Deploy', description: 'deploy project', path: path.join(tmpDir, 'deploy.ps1') }]);
+  });
+
+  it('runs scripts with default parameters and shows status', async () => {
+    const spawnMock = jest
+      .spyOn(child_process, 'spawn')
+      .mockImplementation((): any => {
+        const handlers: Record<string, (code: number) => void> = {};
+        return {
+          on: (event: string, cb: (code: number) => void) => {
+            handlers[event] = cb;
+          },
+          kill: jest.fn(),
+          __handlers: handlers,
+        } as any;
+      });
+
+    const script = {
+      id: 'build',
+      name: 'Build',
+      description: 'build project',
+      path: path.join(tmpDir, 'build.ps1'),
+    } as const;
+
+    const statuses: string[] = [];
+    const promise = runScript(script, ['-Foo', 'Bar'], (s) => statuses.push(s));
+
+    const child = spawnMock.mock.results[0].value;
+    child.__handlers.exit(0);
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledWith('pwsh', [
+      '-File',
+      script.path,
+      '-Foo',
+      'Bar',
+    ]);
+    expect(statuses).toEqual(['running', 'success']);
+
+    spawnMock.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- add failing test for executing PowerShell scripts with default parameters and status updates
- stub out `runScript` implementation
- mark task 4.1.3 complete in task list

## Testing
- `npm install`
- `npm test` *(fails: not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_685d552891f88322a805bd46e331c4f8