### PR TITLE
Implement customize dialog for script runner

### DIFF
--- a/plugins/script-runner/index.ts
+++ b/plugins/script-runner/index.ts
@@ -81,3 +81,18 @@ export const runScript = (
     });
   });
 };
+
+export type CustomizeOptions = {
+  prompt: (current: string[]) => Promise<string[]> | string[];
+  saveDefaults: (scriptId: string, params: string[]) => Promise<void> | void;
+};
+
+export const customizeScript = async (
+  script: Script,
+  currentParams: string[],
+  options: CustomizeOptions,
+): Promise<string[]> => {
+  const params = await options.prompt(currentParams);
+  await options.saveDefaults(script.id, params);
+  return params;
+};

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -109,8 +109,8 @@
     - [x] 4.1.3 Write failing test for running scripts with default parameters and showing status indicator.
     - [x] 4.1.4 Implement running scripts with default parameters and showing status indicator.
     - [x] 4.1.5 Write failing test for Customize dialog to override parameters and save defaults.
-    - [ ] 4.1.6 Implement Customize dialog to override parameters and save defaults.
-    - [ ] 4.1.7 Write failing test for Edit and Remove actions for script configurations.
+    - [x] 4.1.6 Implement Customize dialog to override parameters and save defaults.
+    - [x] 4.1.7 Write failing test for Edit and Remove actions for script configurations.
     - [ ] 4.1.8 Implement Edit and Remove actions for script configurations.
     - [ ] 4.1.9 Write failing test for setup dialog when new scripts are discovered.
     - [ ] 4.1.10 Implement setup dialog for newly discovered scripts.

--- a/tests/plugins/script-runner.test.ts
+++ b/tests/plugins/script-runner.test.ts
@@ -95,4 +95,23 @@ describe('script runner plugin', () => {
     expect(saveDefaults).toHaveBeenCalledWith(script.id, ['-Foo', 'Baz']);
     expect(result).toEqual(['-Foo', 'Baz']);
   });
+
+  it('edits and removes script configurations', async () => {
+    const { editScriptConfig, removeScriptConfig } = await import(
+      '../../plugins/script-runner/index.js'
+    );
+    const updateConfig = jest.fn();
+    const prompt = jest.fn().mockResolvedValue(['-Foo', 'Baz']);
+
+    let config = { build: ['-Foo', 'Bar'] };
+    config = await editScriptConfig('build', config, { prompt, updateConfig });
+
+    expect(prompt).toHaveBeenCalledWith(['-Foo', 'Bar']);
+    expect(updateConfig).toHaveBeenCalledWith({ build: ['-Foo', 'Baz'] });
+    expect(config).toEqual({ build: ['-Foo', 'Baz'] });
+
+    config = await removeScriptConfig('build', config, { updateConfig });
+    expect(updateConfig).toHaveBeenCalledWith({});
+    expect(config).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary
- add customizeScript function to Script Runner plugin
- document completed tasks
- add failing tests for edit/remove config actions

## Testing
- `npm test --silent` *(fails: editScriptConfig/removeScriptConfig not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_685d5cfba804832284f7b21b479f5551