### PR TITLE
Implement setup dialog for new scripts

### DIFF
--- a/plugins/script-runner/index.ts
+++ b/plugins/script-runner/index.ts
@@ -135,3 +135,32 @@ export const removeScriptConfig = async <T extends Record<string, string[]>, K e
   await options.updateConfig(updated);
   return updated;
 };
+
+export type SetupNewScriptsOptions<T extends Record<string, string[]>> = {
+  prompt: (script: Script) => Promise<string[]> | string[];
+  updateConfig: (config: T) => Promise<void> | void;
+};
+
+export const setupNewScripts = async <T extends Record<string, string[]>>(
+  scripts: Script[],
+  config: T,
+  options: SetupNewScriptsOptions<T>,
+): Promise<T> => {
+  let updated = { ...config } as T;
+  let changed = false;
+
+  for (const script of scripts) {
+    if (Object.prototype.hasOwnProperty.call(updated, script.id)) {
+      continue;
+    }
+    const params = await options.prompt(script);
+    updated = { ...updated, [script.id]: params } as T;
+    changed = true;
+  }
+
+  if (changed) {
+    await options.updateConfig(updated);
+  }
+
+  return updated;
+};

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -112,8 +112,8 @@
     - [x] 4.1.6 Implement Customize dialog to override parameters and save defaults.
     - [x] 4.1.7 Write failing test for Edit and Remove actions for script configurations.
     - [x] 4.1.8 Implement Edit and Remove actions for script configurations.
-    - [ ] 4.1.9 Write failing test for setup dialog when new scripts are discovered.
-    - [ ] 4.1.10 Implement setup dialog for newly discovered scripts.
+    - [x] 4.1.9 Write failing test for setup dialog when new scripts are discovered.
+    - [x] 4.1.10 Implement setup dialog for newly discovered scripts.
     - [ ] 4.1.11 Write failing test for Clear Output and Copy Output actions.
     - [ ] 4.1.12 Implement Clear Output and Copy Output actions for the output panel.
   - [ ] 4.2 Context Generator Plugin

--- a/tests/plugins/script-runner.test.ts
+++ b/tests/plugins/script-runner.test.ts
@@ -114,4 +114,41 @@ describe('script runner plugin', () => {
     expect(updateConfig).toHaveBeenCalledWith({});
     expect(config).toEqual({});
   });
+
+  it('opens setup dialog when new scripts are discovered', async () => {
+    const { setupNewScripts } = await import(
+      '../../plugins/script-runner/index.js'
+    );
+    const prompt = jest.fn().mockResolvedValue(['-Default']);
+    const updateConfig = jest.fn();
+
+    const scripts = [
+      {
+        id: 'build',
+        name: 'Build',
+        description: 'build project',
+        path: path.join(tmpDir, 'build.ps1'),
+      },
+      {
+        id: 'deploy',
+        name: 'Deploy',
+        description: 'deploy project',
+        path: path.join(tmpDir, 'deploy.ps1'),
+      },
+    ];
+
+    const config = await setupNewScripts(
+      scripts,
+      { build: ['-Foo'] },
+      { prompt, updateConfig },
+    );
+
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(prompt).toHaveBeenCalledWith(scripts[1]);
+    expect(updateConfig).toHaveBeenCalledWith({
+      build: ['-Foo'],
+      deploy: ['-Default'],
+    });
+    expect(config).toEqual({ build: ['-Foo'], deploy: ['-Default'] });
+  });
 });


### PR DESCRIPTION
## Summary
- add failing test and feature for script setup dialog
- update task list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d625a01848322865458767c07a300