### PR TITLE
Implement context generation progress

### DIFF
--- a/plugins/context-generator/index.tsx
+++ b/plugins/context-generator/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import fs from 'fs/promises';
 import { FileScanner, type FileNode } from '../../src/ui/components/FileScanner.js';
 
 export type ContextGeneratorProps = {
@@ -7,6 +8,7 @@ export type ContextGeneratorProps = {
 
 export const ContextGenerator: React.FC<ContextGeneratorProps> = ({ tree }) => {
   const [selected, setSelected] = useState<string[]>([]);
+  const [progress, setProgress] = useState<{ index: number; total: number; chars: number } | null>(null);
 
   const handleToggle = (path: string, checked: boolean) => {
     setSelected((prev) =>
@@ -14,9 +16,25 @@ export const ContextGenerator: React.FC<ContextGeneratorProps> = ({ tree }) => {
     );
   };
 
+  const handleGenerate = async () => {
+    const total = selected.length;
+    let chars = 0;
+    for (let i = 0; i < selected.length; i++) {
+      const content = await fs.readFile(selected[i], 'utf8');
+      chars += content.length;
+      setProgress({ index: i + 1, total, chars });
+    }
+  };
+
   return (
     <div>
       <FileScanner tree={tree} onToggleFile={handleToggle} />
+      <button type="button" onClick={handleGenerate}>Generate Context</button>
+      {progress && (
+        <div>
+          Progress: {progress.index}/{progress.total} Characters: {progress.chars}
+        </div>
+      )}
       <ul>
         {selected.map((p) => (
           <li key={p}>{p}</li>

--- a/tests/plugins/context-generator.test.tsx
+++ b/tests/plugins/context-generator.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import fs from 'fs/promises';
+import path from 'path';
 import type { FileNode } from '../../src/ui/components/FileScanner.js';
 import { ContextGenerator } from '../../plugins/context-generator/index.js';
 
@@ -24,5 +26,32 @@ describe('context generator plugin', () => {
 
     expect(screen.getByText('/src/index.ts')).toBeInTheDocument();
     expect(screen.getByText('/README.md')).toBeInTheDocument();
+  });
+
+  it('shows progress and character count when generating context', async () => {
+    const dir = path.join(__dirname, 'tmp');
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.mkdir(dir, { recursive: true });
+    const fileA = path.join(dir, 'a.txt');
+    const fileB = path.join(dir, 'b.txt');
+    await fs.writeFile(fileA, 'abc');
+    await fs.writeFile(fileB, 'defg');
+
+    const tree: FileNode[] = [
+      { name: 'a.txt', path: fileA, isDirectory: false },
+      { name: 'b.txt', path: fileB, isDirectory: false },
+    ];
+
+    render(<ContextGenerator tree={tree} />);
+
+    await userEvent.click(screen.getByLabelText('a.txt'));
+    await userEvent.click(screen.getByLabelText('b.txt'));
+    await userEvent.click(screen.getByRole('button', { name: /generate context/i }));
+
+    const charCount = 3 + 4;
+    expect(await screen.findByText(/progress: 2\/2/i)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(`characters: ${charCount}`, 'i'))).toBeInTheDocument();
+
+    await fs.rm(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- add Generate Context button to context-generator plugin
- show progress and character count while reading selected files
- test progress and character count display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6e1c4ac48322951eaa0a7d5b745e