### PR TITLE
Implement As-Built template dropdown

### DIFF
--- a/plugins/as-built-documenter/index.tsx
+++ b/plugins/as-built-documenter/index.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+
+export type AsBuiltDocumenterProps = {
+  templates: string[];
+};
+
+export const AsBuiltDocumenter: React.FC<AsBuiltDocumenterProps> = ({ templates }) => {
+  const [template, setTemplate] = useState('');
+  return (
+    <select
+      aria-label="Template File"
+      value={template}
+      onChange={(e) => setTemplate(e.target.value)}
+    >
+      <option value="">(none)</option>
+      {templates.map((t) => (
+        <option key={t} value={t}>
+          {t}
+        </option>
+      ))}
+    </select>
+  );
+};

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -25,7 +25,8 @@
 - `tests/plugins/script-runner.test.ts` - Tests for Script Runner plugin behavior, including customizing parameters.
 - `tests/plugins/context-generator.test.tsx` - Tests for Context Generator plugin UI behavior.
   - `plugins/context-generator/index.tsx` - Folder scanning and text bundling plugin.
-- `plugins/as-built-documenter/index.ts` - Documentation generation plugin.
+  - `plugins/as-built-documenter/index.tsx` - Documentation generation plugin UI.
+  - `tests/plugins/as-built-documenter.test.tsx` - Tests for As-Built Documenter plugin behavior.
 - `plugins/customer-links/index.ts` - Customer links viewer and exporter.
 - `config/app-config.json5` - Main application configuration file.
 - `tests/core/**/*.ts` - Jest unit tests for core modules and components.
@@ -127,8 +128,8 @@
     - [x] 4.2.7 Write failing test for output area displaying progress and character count.
     - [x] 4.2.8 Implement output area displaying progress and character count.
   - [ ] 4.3 As-Built Documenter Plugin
-    - [ ] 4.3.1 Write failing test for Template File dropdown listing Markdown templates and allowing clearing.
-    - [ ] 4.3.2 Implement Template File dropdown listing Markdown templates and allowing clearing.
+    - [x] 4.3.1 Write failing test for Template File dropdown listing Markdown templates and allowing clearing.
+    - [x] 4.3.2 Implement Template File dropdown listing Markdown templates and allowing clearing.
     - [ ] 4.3.3 Write failing test for Load button opening any `.md` file.
     - [ ] 4.3.4 Implement Load button opening any `.md` file.
     - [ ] 4.3.5 Write failing test for toolbar to format and insert `{{#each}}` snippets.

--- a/tests/plugins/as-built-documenter.test.tsx
+++ b/tests/plugins/as-built-documenter.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AsBuiltDocumenter } from '../../plugins/as-built-documenter/index.js';
+
+describe('as-built documenter plugin', () => {
+  it('lists Markdown templates in dropdown and allows clearing', async () => {
+    render(<AsBuiltDocumenter templates={['one.md', 'two.md']} />);
+
+    const select = screen.getByLabelText(/template file/i) as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveValue('');
+    expect(select.options).toHaveLength(3);
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      '',
+      'one.md',
+      'two.md',
+    ]);
+
+    await userEvent.selectOptions(select, 'one.md');
+    expect(select.value).toBe('one.md');
+
+    await userEvent.selectOptions(select, '');
+    expect(select.value).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- create As-Built Documenter plugin with template dropdown UI
- add initial tests for listing templates and clearing selection
- update task list

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d868d7a5083229e881298ceabaa24