### PR TITLE
Implement markdown load for as-built documenter

### DIFF
--- a/plugins/as-built-documenter/index.tsx
+++ b/plugins/as-built-documenter/index.tsx
@@ -2,22 +2,39 @@ import React, { useState } from 'react';
 
 export type AsBuiltDocumenterProps = {
   templates: string[];
+  onLoad?: (file: File) => void;
 };
 
-export const AsBuiltDocumenter: React.FC<AsBuiltDocumenterProps> = ({ templates }) => {
+export const AsBuiltDocumenter: React.FC<AsBuiltDocumenterProps> = ({
+  templates,
+  onLoad,
+}) => {
   const [template, setTemplate] = useState('');
   return (
-    <select
-      aria-label="Template File"
-      value={template}
-      onChange={(e) => setTemplate(e.target.value)}
-    >
-      <option value="">(none)</option>
-      {templates.map((t) => (
-        <option key={t} value={t}>
-          {t}
-        </option>
-      ))}
-    </select>
+    <>
+      <select
+        aria-label="Template File"
+        value={template}
+        onChange={(e) => setTemplate(e.target.value)}
+      >
+        <option value="">(none)</option>
+        {templates.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      <input
+        type="file"
+        accept=".md"
+        aria-label="Load Template"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) {
+            onLoad?.(file);
+          }
+        }}
+      />
+    </>
   );
 };

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -130,8 +130,8 @@
   - [ ] 4.3 As-Built Documenter Plugin
     - [x] 4.3.1 Write failing test for Template File dropdown listing Markdown templates and allowing clearing.
     - [x] 4.3.2 Implement Template File dropdown listing Markdown templates and allowing clearing.
-    - [ ] 4.3.3 Write failing test for Load button opening any `.md` file.
-    - [ ] 4.3.4 Implement Load button opening any `.md` file.
+    - [x] 4.3.3 Write failing test for Load button opening any `.md` file.
+    - [x] 4.3.4 Implement Load button opening any `.md` file.
     - [ ] 4.3.5 Write failing test for toolbar to format and insert `{{#each}}` snippets.
     - [ ] 4.3.6 Implement toolbar to format and insert `{{#each}}` snippets.
     - [ ] 4.3.7 Write failing test for embedding CodeMirror editor for editing templates.

--- a/tests/plugins/as-built-documenter.test.tsx
+++ b/tests/plugins/as-built-documenter.test.tsx
@@ -22,4 +22,16 @@ describe('as-built documenter plugin', () => {
     await userEvent.selectOptions(select, '');
     expect(select.value).toBe('');
   });
+
+  it('loads a markdown file using the Load button', async () => {
+    const onLoad = jest.fn();
+    render(<AsBuiltDocumenter templates={[]} onLoad={onLoad} />);
+
+    const input = screen.getByLabelText(/load template/i) as HTMLInputElement;
+    const file = new File(['# Heading'], 'test.md', { type: 'text/markdown' });
+
+    await userEvent.upload(input, file);
+
+    expect(onLoad).toHaveBeenCalledWith(file);
+  });
 });


### PR DESCRIPTION
## Summary
- allow As-Built Documenter to load markdown templates
- test markdown file loading behaviour
- update task list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d9a8388888322872c7395f2a9db68