### PR TITLE
Implement sample data loading for as-built documenter

### DIFF
--- a/plugins/as-built-documenter/index.tsx
+++ b/plugins/as-built-documenter/index.tsx
@@ -21,6 +21,8 @@ export const AsBuiltDocumenter: React.FC<AsBuiltDocumenterProps> = ({
 }) => {
   const [template, setTemplate] = useState('');
   const [content, setContent] = useState(initialContent ?? '');
+  const [sourceId, setSourceId] = useState('');
+  const [sample, setSample] = useState<unknown>(null);
 
   const insertEach = () => {
     setContent((c: string) => `${c}{{#each items}}\n{{/each}}`);
@@ -61,7 +63,11 @@ export const AsBuiltDocumenter: React.FC<AsBuiltDocumenterProps> = ({
           Each
         </button>
       </div>
-      <select aria-label="Data Source" value="" onChange={() => {}}>
+      <select
+        aria-label="Data Source"
+        value={sourceId}
+        onChange={(e) => setSourceId(e.target.value)}
+      >
         <option value="">(none)</option>
         {Object.keys(dataSources).map((id) => (
           <option key={id} value={id}>
@@ -69,6 +75,20 @@ export const AsBuiltDocumenter: React.FC<AsBuiltDocumenterProps> = ({
           </option>
         ))}
       </select>
+      <button
+        type="button"
+        onClick={async () => {
+          if (!sourceId) return;
+          const data = await (window as any).ipcRenderer.invoke(
+            'load-sample-data',
+            { id: sourceId, ...dataSources[sourceId] },
+          );
+          setSample(data);
+        }}
+      >
+        Load Sample Data
+      </button>
+      {sample && <pre>{JSON.stringify(sample, null, 2)}</pre>}
       <CodeMirror
         aria-label="Template Editor"
         value={content}

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -140,8 +140,8 @@
     - [x] 4.3.10 Implement Save button writing templates to `templates/as-built`.
     - [x] 4.3.11 Write failing test for Data Source dropdown populated from configuration.
     - [x] 4.3.12 Implement Data Source dropdown populated from configuration.
-    - [ ] 4.3.13 Write failing test for loading sample data via IPC.
-    - [ ] 4.3.14 Implement loading sample data via IPC.
+    - [x] 4.3.13 Write failing test for loading sample data via IPC.
+    - [x] 4.3.14 Implement loading sample data via IPC.
     - [ ] 4.3.15 Write failing test for Sample Data Table supporting copying loops or field names.
     - [ ] 4.3.16 Implement Sample Data Table supporting copying loops or field names.
     - [ ] 4.3.17 Write failing test for Prev/Next buttons paging through sample data.

--- a/tests/plugins/as-built-documenter.test.tsx
+++ b/tests/plugins/as-built-documenter.test.tsx
@@ -94,4 +94,28 @@ describe('as-built documenter plugin', () => {
       'bar',
     ]);
   });
+
+  it('loads sample data via IPC', async () => {
+    const invoke = jest.fn().mockResolvedValue([{ id: 1 }]);
+    (window as any).ipcRenderer = { invoke };
+
+    render(
+      <AsBuiltDocumenter
+        templates={[]}
+        dataSources={{ foo: { url: 'http://foo' } }}
+      />,
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText(/data source/i), 'foo');
+    await userEvent.click(
+      screen.getByRole('button', { name: /load sample data/i }),
+    );
+
+    expect(invoke).toHaveBeenCalledWith('load-sample-data', {
+      id: 'foo',
+      url: 'http://foo',
+    });
+
+    expect(await screen.findByText(/"id": 1/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- load sample data in As-Built Documenter via IPC
- show returned data and update component state
- test IPC sample data loading
- update task list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685db93170f08322896351720f036735