### PR TITLE
Implement failing test for customer links plugin

### DIFF
--- a/plugins/customer-links/index.ts
+++ b/plugins/customer-links/index.ts
@@ -1,0 +1,9 @@
+export type CustomerSite = {
+  id: string;
+  name: string;
+  url: string;
+};
+
+export const scanCustomerSites = async (_filePath: string): Promise<CustomerSite[]> => {
+  return [];
+};

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -28,6 +28,7 @@
   - `plugins/as-built-documenter/index.tsx` - Documentation generation plugin UI.
   - `tests/plugins/as-built-documenter.test.tsx` - Tests for As-Built Documenter plugin behavior.
 - `plugins/customer-links/index.ts` - Customer links viewer and exporter.
+- `tests/plugins/customer-links.test.ts` - Tests for Customer Links plugin behavior.
 - `config/app-config.json5` - Main application configuration file.
 - `tests/core/**/*.ts` - Jest unit tests for core modules and components.
 - `tests/e2e/**/*.spec.ts` - Playwright end-to-end tests for plugin flows.
@@ -151,7 +152,7 @@
     - [x] 4.3.21 Write failing test for Add Data Source button prompting for ID and URL and saving immediately.
     - [x] 4.3.22 Implement Add Data Source button prompting for ID and URL and saving immediately.
   - [ ] 4.4 Customer Links Plugin
-    - [ ] 4.4.1 Write failing test for scanning configurable JSON or JSON5 file for customer sites.
+    - [x] 4.4.1 Write failing test for scanning configurable JSON or JSON5 file for customer sites.
     - [ ] 4.4.2 Implement scanning configurable JSON or JSON5 file for customer sites.
     - [ ] 4.4.3 Write failing test for generating standalone HTML and rendering it inside the plugin.
     - [ ] 4.4.4 Implement generating standalone HTML and rendering it inside the plugin.

--- a/tests/plugins/customer-links.test.ts
+++ b/tests/plugins/customer-links.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { scanCustomerSites } from '../../plugins/customer-links/index.js';
+
+describe('customer links plugin', () => {
+  const dir = path.join(__dirname, 'data');
+  const jsonPath = path.join(dir, 'customers.json5');
+
+  beforeEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.mkdir(dir, { recursive: true });
+    const content = `[
+      // test comment
+      { id: 'acme', name: 'Acme Corp', url: 'https://acme.com' },
+      { id: 'foo', name: 'Foo Inc', url: 'https://foo.example.com' },
+    ]`;
+    await fs.writeFile(jsonPath, content, 'utf8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('scans configurable JSON or JSON5 file for customer sites', async () => {
+    const sites = await scanCustomerSites(jsonPath);
+    expect(sites).toEqual([
+      { id: 'acme', name: 'Acme Corp', url: 'https://acme.com' },
+      { id: 'foo', name: 'Foo Inc', url: 'https://foo.example.com' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add stub for customer links plugin
- write failing test for scanning customer sites
- track new test file in task list
- mark task 4.4.1 complete

## Testing
- `npm install`
- `npm test` *(fails: customer links plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685de1b36b3c83228436e9d40247e861