### PR TITLE
Implement task 4.4.3

### DIFF
--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -28,7 +28,7 @@
   - `plugins/as-built-documenter/index.tsx` - Documentation generation plugin UI.
   - `tests/plugins/as-built-documenter.test.tsx` - Tests for As-Built Documenter plugin behavior.
 - `plugins/customer-links/index.ts` - Customer links viewer and exporter.
-- `tests/plugins/customer-links.test.ts` - Tests for Customer Links plugin behavior.
+- `tests/plugins/customer-links.test.tsx` - Tests for Customer Links plugin behavior.
 - `config/app-config.json5` - Main application configuration file.
 - `tests/core/**/*.ts` - Jest unit tests for core modules and components.
 - `tests/e2e/**/*.spec.ts` - Playwright end-to-end tests for plugin flows.
@@ -154,7 +154,7 @@
   - [ ] 4.4 Customer Links Plugin
     - [x] 4.4.1 Write failing test for scanning configurable JSON or JSON5 file for customer sites.
     - [x] 4.4.2 Implement scanning configurable JSON or JSON5 file for customer sites.
-    - [ ] 4.4.3 Write failing test for generating standalone HTML and rendering it inside the plugin.
+    - [x] 4.4.3 Write failing test for generating standalone HTML and rendering it inside the plugin.
     - [ ] 4.4.4 Implement generating standalone HTML and rendering it inside the plugin.
     - [ ] 4.4.5 Write failing test for saving generated HTML, CSS, and JavaScript to configured output path.
     - [ ] 4.4.6 Implement saving generated HTML, CSS, and JavaScript to configured output path.

--- a/tests/plugins/customer-links.test.tsx
+++ b/tests/plugins/customer-links.test.tsx
@@ -1,7 +1,13 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
-import { scanCustomerSites } from '../../plugins/customer-links/index.js';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  scanCustomerSites,
+  generateCustomerLinksHtml,
+  CustomerLinks,
+} from '../../plugins/customer-links/index.js';
 
 describe('customer links plugin', () => {
   const dir = path.join(__dirname, 'data');
@@ -28,5 +34,19 @@ describe('customer links plugin', () => {
       { id: 'acme', name: 'Acme Corp', url: 'https://acme.com' },
       { id: 'foo', name: 'Foo Inc', url: 'https://foo.example.com' },
     ]);
+  });
+  it('generates standalone HTML and renders it', () => {
+    const sites = [
+      { id: 'acme', name: 'Acme Corp', url: 'https://acme.com' },
+      { id: 'foo', name: 'Foo Inc', url: 'https://foo.example.com' },
+    ];
+
+    const html = generateCustomerLinksHtml(sites);
+    expect(html).toContain('<a href="https://acme.com">Acme Corp</a>');
+    expect(html).toContain('<a href="https://foo.example.com">Foo Inc</a>');
+
+    render(<CustomerLinks sites={sites} />);
+    expect(screen.getByText('Acme Corp').getAttribute('href')).toBe('https://acme.com');
+    expect(screen.getByText('Foo Inc').getAttribute('href')).toBe('https://foo.example.com');
   });
 });


### PR DESCRIPTION
## Summary
- add failing test for generating HTML for customer links
- mark task 4.4.3 as complete in task list
- rename customer links test file to `.tsx`

## Testing
- `npm install`
- `npm test` *(fails: generateCustomerLinksHtml not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_685de526a73883229195eacd385999d6