### PR TITLE
Add Playwright e2e tests and update config

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,7 @@ const config: Config = {
     '\\.(css)$': '<rootDir>/tests/style-mock.js',
   },
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
+  testPathIgnorePatterns: ['<rootDir>/tests/e2e/'],
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "omnia",
       "version": "0.1.0",
       "dependencies": {
+        "@playwright/test": "^1.53.1",
         "ts-node": "^10.9.2"
       },
       "devDependencies": {
@@ -1568,6 +1569,21 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -4967,7 +4983,6 @@
       "version": "1.53.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
       "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.53.1"
@@ -4986,7 +5001,6 @@
       "version": "1.53.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
       "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -4999,7 +5013,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@codemirror/lang-markdown": "^6.1.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.5",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@uiw/react-codemirror": "^4.23.13",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.2",
     "json5": "^2.2.3",
@@ -21,13 +23,12 @@
     "playwright": "^1.41.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@uiw/react-codemirror": "^4.23.13",
-    "@codemirror/lang-markdown": "^6.1.1",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2",
     "zod": "^3.22.4"
   },
   "dependencies": {
+    "@playwright/test": "^1.53.1",
     "ts-node": "^10.9.2"
   }
 }

--- a/tasks/tasks-redoprompt.md
+++ b/tasks/tasks-redoprompt.md
@@ -35,6 +35,7 @@
 - `config/app-config.json5` - Main application configuration file.
 - `tests/core/**/*.ts` - Jest unit tests for core modules and components.
 - `tests/e2e/**/*.spec.ts` - Playwright end-to-end tests for plugin flows.
+- `tests/e2e/plugin-workflows.spec.ts` - End-to-end tests exercising plugin workflows.
 - `tasks/tasks-redoprompt.md` - Task list for project management.
 
 ### Notes
@@ -170,5 +171,5 @@
   - [x] 5.3 Write failing test for loading plugin interfaces via `plugin-ui-loader.ts`.
   - [x] 5.4 Implement loading plugin interfaces via `plugin-ui-loader.ts`.
   - [x] 5.5 Write unit tests for core modules and components.
-  - [ ] 5.6 Write end-to-end tests covering plugin workflows.
+  - [x] 5.6 Write end-to-end tests covering plugin workflows.
   - [ ] 5.7 Ensure full test coverage before merging changes.

--- a/tests/e2e/plugin-workflows.spec.ts
+++ b/tests/e2e/plugin-workflows.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs/promises';
+import path from 'path';
+import child_process from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import {
+  discoverScripts,
+  filterScripts,
+  customizeScript,
+  editScriptConfig,
+  removeScriptConfig,
+  setupNewScripts,
+  createOutputManager,
+} from '../../plugins/script-runner/index.js';
+
+test.describe('plugin workflows', () => {
+  test('script runner end-to-end workflow', async () => {
+    const dir = path.join(__dirname, 'scripts');
+    await fs.rm(dir, { recursive: true, force: true });
+    await fs.mkdir(dir, { recursive: true });
+    const buildPath = path.join(dir, 'build.ps1');
+    const deployPath = path.join(dir, 'deploy.ps1');
+    await fs.writeFile(
+      buildPath,
+      '# ID: build\n# Name: Build\n# Description: build project\n'
+    );
+    await fs.writeFile(
+      deployPath,
+      '# ID: deploy\n# Name: Deploy\n# Description: deploy project\n'
+    );
+
+    const scripts = await discoverScripts(dir);
+    expect(scripts.map((s) => s.id).sort()).toEqual(['build', 'deploy']);
+
+    const filtered = filterScripts(scripts, 'deploy');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe('deploy');
+
+
+
+    const params = await customizeScript(filtered[0], ['-Foo'], {
+      prompt: async () => ['-Foo', 'Bar'],
+      saveDefaults: async () => {},
+    });
+    expect(params).toEqual(['-Foo', 'Bar']);
+
+    let config = { build: ['-Foo'] } as Record<string, string[]>;
+    config = await editScriptConfig('build', config, {
+      prompt: async () => ['-Foo', 'Baz'],
+      updateConfig: async () => {},
+    });
+    expect(config).toEqual({ build: ['-Foo', 'Baz'] });
+    config = await removeScriptConfig('build', config, { updateConfig: async () => {} });
+    expect(config).toEqual({});
+
+    const setupConfig = await setupNewScripts(scripts, {}, {
+      prompt: async () => ['-Default'],
+      updateConfig: async () => {},
+    });
+    expect(Object.keys(setupConfig)).toEqual(['build', 'deploy']);
+
+    const output = createOutputManager({ copy: () => {} });
+    output.append('foo');
+    output.append('bar');
+    expect(output.get()).toBe('foobar');
+    output.clear();
+    expect(output.get()).toBe('');
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+});


### PR DESCRIPTION
## Summary
- add new Playwright test `plugin-workflows.spec.ts`
- configure Jest to ignore e2e tests
- update tasks to mark e2e tests complete

## Testing
- `npm run test:e2e`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e00fa97c48322b24ecb56206647cb