### PR TITLE
Add build and dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "type": "module",
   "scripts": {
     "test": "jest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "clean": "node -e \"import('fs').then(fs=>fs.rmSync('dist',{recursive:true,force:true}))\"",
+    "build": "npm run clean && tsc",
+    "dev": "ts-node-esm src/index.ts",
+    "start": "node dist/index.js"
   },
   "devDependencies": {
     "@codemirror/lang-markdown": "^6.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+console.log('Omnia application starting...');


### PR DESCRIPTION
## Summary
- add dev, build, start and clean scripts
- add minimal entry point for dev/start

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_685e9401395c8322880554ed5c70f861