### PR TITLE
Fix start script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ This will be an evolution of the ttComander application
 
 1. Install dependencies with `npm install`.
 2. Start the app in development mode using `npm run dev`.
+3. Build the project with `npm run build`.
+4. Run the compiled app using `npm start`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "node -e \"import('fs').then(fs=>fs.rmSync('dist',{recursive:true,force:true}))\"",
     "build": "npm run clean && tsc",
     "dev": "node --loader ts-node/esm src/index.ts",
-    "start": "node dist/index.js"
+    "start": "node dist/src/index.js"
   },
   "devDependencies": {
     "@codemirror/lang-markdown": "^6.1.1",


### PR DESCRIPTION
## Summary
- correct `npm start` path
- document build and start steps in the README

## Testing
- `npm test`
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685ea02a12548322a86de8aeb9b9c57f