### PR TITLE
Add UI renderer

### DIFF
--- a/src/ui/renderer.tsx
+++ b/src/ui/renderer.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useEffect, useRef } from 'react';
+import { CardGrid, type CardGridItem } from './components/CardGrid.js';
+import { loadPluginUI } from './plugin-ui-loader.js';
+
+export type RendererPlugin = {
+  id: string;
+  title: string;
+  props?: Record<string, unknown>;
+};
+
+export type RendererOptions = {
+  container: HTMLElement;
+  pluginsPath: string;
+  plugins: RendererPlugin[];
+};
+
+const PluginPanel: React.FC<{
+  id: string;
+  pluginsPath: string;
+  props?: Record<string, unknown>;
+}> = ({ id, pluginsPath, props }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ref.current) {
+      loadPluginUI(id, { container: ref.current, pluginsPath, props }).catch(() => {});
+    }
+  }, [id, pluginsPath, props]);
+  return <div ref={ref} />;
+};
+
+export const initRenderer = (
+  opts: RendererOptions,
+): Root => {
+  const items: CardGridItem[] = opts.plugins.map((p) => ({
+    title: p.title,
+    content: React.createElement(PluginPanel, {
+      id: p.id,
+      pluginsPath: opts.pluginsPath,
+      props: p.props,
+    }),
+  }));
+
+  const root = createRoot(opts.container);
+  root.render(React.createElement(CardGrid, { items }));
+  return root;
+};

--- a/tests/ui/renderer.test.tsx
+++ b/tests/ui/renderer.test.tsx
@@ -1,0 +1,26 @@
+import { screen, act } from '@testing-library/react';
+import path from 'path';
+import { initRenderer } from '../../src/ui/renderer.js';
+
+it('initializes card grid and loads plugin UI', async () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const pluginsPath = path.join(__dirname, '..', '..', 'plugins');
+  await act(async () => {
+    initRenderer({
+      container,
+      pluginsPath,
+      plugins: [
+        {
+          id: 'context-generator',
+          title: 'Context Generator',
+          props: { tree: [] },
+        },
+      ],
+    });
+  });
+  expect(screen.getByText('Context Generator')).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: /generate context/i }),
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- implement `initRenderer` to load plugin UIs into a card grid
- test renderer initialization with the context generator plugin

## Testing
- `npx jest tests/ui/renderer.test.tsx`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685eadf5b8288322b2d7e8824bf94a56