### PR TITLE
Add UI renderer to startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,25 @@
-console.log('Omnia application starting...');
+import fs from 'fs/promises';
+import path from 'path';
+import { initRenderer } from './ui/renderer.js';
+
+export type StartOptions = {
+  init?: typeof initRenderer;
+};
+
+export const start = async (opts?: StartOptions): Promise<void> => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const pluginsPath = path.join(__dirname, '..', 'plugins');
+  const entries = await fs.readdir(pluginsPath, { withFileTypes: true });
+  const plugins = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => ({ id: e.name, title: e.name.replace(/-/g, ' ') }));
+  const renderer = opts?.init ?? initRenderer;
+  renderer({ container, pluginsPath, plugins });
+};
+
+if (process.env.NODE_ENV !== 'test') {
+  start().catch((err) => {
+    console.error(err);
+  });
+}

--- a/src/ui/renderer.tsx
+++ b/src/ui/renderer.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useEffect, useRef } from 'react';
+import { CardGrid, type CardGridItem } from './components/CardGrid.js';
+import { loadPluginUI } from './plugin-ui-loader.js';
+
+export type RendererPlugin = {
+  id: string;
+  title: string;
+  props?: Record<string, unknown>;
+};
+
+export type RendererOptions = {
+  container: HTMLElement;
+  pluginsPath: string;
+  plugins: RendererPlugin[];
+};
+
+const PluginPanel: React.FC<{
+  id: string;
+  pluginsPath: string;
+  props?: Record<string, unknown>;
+}> = ({ id, pluginsPath, props }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ref.current) {
+      loadPluginUI(id, { container: ref.current, pluginsPath, props }).catch(() => {});
+    }
+  }, [id, pluginsPath, props]);
+  return <div ref={ref} />;
+};
+
+export const initRenderer = (
+  opts: RendererOptions,
+): Root => {
+  const items: CardGridItem[] = opts.plugins.map((p) => ({
+    title: p.title,
+    content: React.createElement(PluginPanel, {
+      id: p.id,
+      pluginsPath: opts.pluginsPath,
+      props: p.props,
+    }),
+  }));
+
+  const root = createRoot(opts.container);
+  root.render(React.createElement(CardGrid, { items }));
+  return root;
+};

--- a/tests/root/startup.test.ts
+++ b/tests/root/startup.test.ts
@@ -1,0 +1,12 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../../src/ui/renderer.js', () => ({
+  initRenderer: jest.fn(),
+}));
+
+it('calls initRenderer with discovered plugins', async () => {
+  const { start } = await import('../../src/index.js');
+  const mockInit = jest.fn();
+  await start({ init: mockInit as any });
+  expect(mockInit).toHaveBeenCalled();
+});

--- a/tests/ui/renderer.test.tsx
+++ b/tests/ui/renderer.test.tsx
@@ -1,0 +1,26 @@
+import { screen, act } from '@testing-library/react';
+import path from 'path';
+import { initRenderer } from '../../src/ui/renderer.js';
+
+it('initializes card grid and loads plugin UI', async () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const pluginsPath = path.join(__dirname, '..', '..', 'plugins');
+  await act(async () => {
+    initRenderer({
+      container,
+      pluginsPath,
+      plugins: [
+        {
+          id: 'context-generator',
+          title: 'Context Generator',
+          props: { tree: [] },
+        },
+      ],
+    });
+  });
+  expect(screen.getByText('Context Generator')).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: /generate context/i }),
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- invoke renderer when starting the app
- allow overriding initRenderer for tests
- test startup uses the renderer

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script)*
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685eadf5b8288322b2d7e8824bf94a56