### PR TITLE
Fix npm run dev by adding CSS loader

### DIFF
--- a/loaders/css-loader.js
+++ b/loaders/css-loader.js
@@ -1,0 +1,9 @@
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.css')) {
+    return {
+      format: 'module',
+      source: "export default {};", shortCircuit: true,
+    };
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:e2e": "playwright test",
     "clean": "node -e \"import('fs').then(fs=>fs.rmSync('dist',{recursive:true,force:true}))\"",
     "build": "npm run clean && tsc",
-    "dev": "node --loader ts-node/esm src/index.ts",
+    "dev": "node --loader ts-node/esm --loader ./loaders/css-loader.js src/index.ts",
     "start": "node dist/src/index.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add simple ESM loader to ignore CSS imports
- use loader in dev script so css modules don't break ts-node

## Testing
- `npm test` *(fails: jest not found)*
- `npm run dev` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685ebdc6a78c8322a3a98ebd8431d402