### PR TITLE
Fix npm scripts with jsdom polyfills

### DIFF
--- a/loaders/css-loader.js
+++ b/loaders/css-loader.js
@@ -1,0 +1,17 @@
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.endsWith('.css')) {
+    return { url: new URL(specifier, context.parentURL).href, shortCircuit: true };
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}
+
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.css')) {
+    return {
+      format: 'module',
+      source: 'export default {};',
+      shortCircuit: true,
+    };
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test:e2e": "playwright test",
     "clean": "node -e \"import('fs').then(fs=>fs.rmSync('dist',{recursive:true,force:true}))\"",
     "build": "npm run clean && tsc",
-    "dev": "node --loader ts-node/esm src/index.ts",
-    "start": "node dist/src/index.js"
+    "dev": "node --loader ts-node/esm --loader ./loaders/css-loader.js src/index.ts",
+    "start": "node --loader ./loaders/css-loader.js dist/src/index.js"
   },
   "devDependencies": {
     "@codemirror/lang-markdown": "^6.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,45 @@ export type StartOptions = {
 };
 
 export const start = async (opts?: StartOptions): Promise<void> => {
+  if (typeof document === 'undefined') {
+    const { JSDOM } = await import('jsdom');
+    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+    Object.assign(globalThis, {
+      window: dom.window,
+      document: dom.window.document,
+      HTMLElement: dom.window.HTMLElement,
+    });
+    if (!globalThis.MutationObserver) {
+      globalThis.MutationObserver = class {
+        disconnect() {}
+        observe() {}
+        takeRecords() { return []; }
+      } as unknown as typeof MutationObserver;
+    }
+    if (!window.requestAnimationFrame) {
+      window.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+      window.cancelAnimationFrame = (id) => clearTimeout(id as unknown as NodeJS.Timeout);
+    }
+  }
+
   const container = document.createElement('div');
   document.body.appendChild(container);
-  const pluginsPath = path.join(__dirname, '..', 'plugins');
+  const pluginsPath = path.join(process.cwd(), 'plugins');
   const entries = await fs.readdir(pluginsPath, { withFileTypes: true });
+  const tree: never[] = [];
   const plugins = entries
     .filter((e) => e.isDirectory())
-    .map((e) => ({ id: e.name, title: e.name.replace(/-/g, ' ') }));
+    .map((e) => {
+      const id = e.name;
+      const base = { id, title: id.replace(/-/g, ' ') };
+      if (id === 'context-generator') {
+        return { ...base, props: { tree } };
+      }
+      if (id === 'as-built-documenter') {
+        return { ...base, props: { templates: [] } };
+      }
+      return base;
+    });
   const renderer = opts?.init ?? initRenderer;
   renderer({ container, pluginsPath, plugins });
 };


### PR DESCRIPTION
## Summary
- handle CSS imports with a resolve hook
- polyfill DOM APIs when running in Node
- locate plugins relative to process cwd
- run compiled app with loader to avoid CSS errors

## Testing
- `npm test`
- `npm start`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_685ebdc6a78c8322a3a98ebd8431d402