### PR TITLE
Add electron startup logging

### DIFF
--- a/tests/root/electron-main.test.ts
+++ b/tests/root/electron-main.test.ts
@@ -9,4 +9,14 @@ describe('electron main', () => {
     expect(MockWindow).toHaveBeenCalledWith({ webPreferences: { nodeIntegration: true } });
     expect(loadFile).toHaveBeenCalledWith(expect.stringContaining('index.html'));
   });
+
+  it('logs window lifecycle events', async () => {
+    const loadFile = jest.fn();
+    const MockWindow = jest.fn(() => ({ loadFile }));
+    const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    const { createWindow } = await import('../../src/electron-main.js');
+    await createWindow(MockWindow as any, logger as any);
+    expect(logger.info).toHaveBeenCalledWith('Creating browser window');
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('index.html'));
+  });
 });


### PR DESCRIPTION
## Summary
- log BrowserWindow creation and file load path
- expose logger in electron start sequence
- test logging behavior in `createWindow`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed701e56083229f3e06cb45c2a980