### PR TITLE
Add automatic Electron startup

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import type { BrowserWindow as ElectronBrowserWindow, App } from 'electron';
 import type { Logger } from './core/logger.js';
+import { createLogger } from './core/logger.js';
 
 let electron: { BrowserWindow: typeof ElectronBrowserWindow; app: App } | undefined;
 
@@ -54,4 +55,10 @@ export const startElectron = (
     });
   });
 };
+
+if (process.env.NODE_ENV !== 'test') {
+  const logPath = path.join(process.cwd(), 'app.log');
+  const logger = createLogger('electron-main', logPath);
+  startElectron(undefined, logger);
+}
 

--- a/tests/root/electron-main.test.ts
+++ b/tests/root/electron-main.test.ts
@@ -1,5 +1,20 @@
 import { jest } from '@jest/globals';
 
+const whenReady = jest.fn(async () => {});
+const on = jest.fn();
+const quit = jest.fn();
+const BrowserWindow = jest.fn(() => ({ loadFile: jest.fn() }));
+(BrowserWindow as any).getAllWindows = jest.fn(() => []);
+
+jest.mock('electron', () => ({
+  BrowserWindow,
+  app: { whenReady, on, quit },
+}));
+
+const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+const createLogger = jest.fn(() => logger);
+jest.mock('../../src/core/logger.js', () => ({ createLogger }));
+
 describe('electron main', () => {
   it('loads index.html in BrowserWindow', async () => {
     const loadFile = jest.fn();
@@ -18,5 +33,19 @@ describe('electron main', () => {
     await createWindow(MockWindow as any, logger as any);
     expect(logger.info).toHaveBeenCalledWith('Creating browser window');
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('index.html'));
+  });
+
+  it('starts Electron when imported outside test env', async () => {
+    jest.resetModules();
+    process.env.NODE_ENV = 'production';
+
+    await import('../../src/electron-main.js');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(createLogger).toHaveBeenCalled();
+    expect(whenReady).toHaveBeenCalled();
+
+    process.env.NODE_ENV = 'test';
   });
 });


### PR DESCRIPTION
## Summary
- create a logger in `electron-main.ts`
- automatically run `startElectron()` when NODE_ENV is not `test`
- verify the auto-start behavior in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef45a813c8322864c2ef53fef8fb7