### PR TITLE
Add conditional electron startup and tests

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -55,3 +55,7 @@ export const startElectron = (
   });
 };
 
+if (process.env.NODE_ENV !== 'test') {
+  startElectron();
+}
+

--- a/tests/root/electron-main.test.ts
+++ b/tests/root/electron-main.test.ts
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { spawnSync } from 'child_process';
 
 describe('electron main', () => {
   it('loads index.html in BrowserWindow', async () => {
@@ -18,5 +19,23 @@ describe('electron main', () => {
     await createWindow(MockWindow as any, logger as any);
     expect(logger.info).toHaveBeenCalledWith('Creating browser window');
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('index.html'));
+  });
+
+  it('starts Electron on execution when NODE_ENV is not test', () => {
+    const result = spawnSync(
+      'node',
+      ['--loader', 'ts-node/esm', 'src/electron-main.ts'],
+      { env: { ...process.env, NODE_ENV: 'development' } },
+    );
+    expect(result.status).not.toBe(0);
+  });
+
+  it('does not start Electron during tests', () => {
+    const result = spawnSync(
+      'node',
+      ['--loader', 'ts-node/esm', 'src/electron-main.ts'],
+      { env: { ...process.env, NODE_ENV: 'test' } },
+    );
+    expect(result.status).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- start Electron automatically outside test environment
- cover Electron startup behavior with new tests

## Testing
- `npm test`
- `npm run electron` *(fails: running as root without --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_685f13a00878832294968fb5ced07bfe