### PR TITLE
Fix Electron blank window issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
   <body>
+    <link rel="stylesheet" href="./src/ui/components/CardGrid.css" />
+    <link rel="stylesheet" href="./src/ui/components/FileScanner.css" />
+    <link rel="stylesheet" href="./src/ui/components/JsonEditor.css" />
     <script type="module" src="./dist/src/index.js"></script>
   </body>
 </html>

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,7 @@ const config: Config = {
     '\\.(css)$': '<rootDir>/tests/style-mock.js',
   },
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
-  testPathIgnorePatterns: ['<rootDir>/tests/e2e/'],
+  testPathIgnorePatterns: ['<rootDir>/tests/e2e/', '<rootDir>/dist/'],
 };
 
 export default config;

--- a/src/ui/components/CardGrid.tsx
+++ b/src/ui/components/CardGrid.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import './CardGrid.css';
 
 export type CardGridItem = {
   title: string;

--- a/src/ui/components/FileScanner.tsx
+++ b/src/ui/components/FileScanner.tsx
@@ -1,7 +1,6 @@
 
 import React, { useState } from 'react';
 
-import './FileScanner.css';
 
 export type FileNode = {
   name: string;

--- a/src/ui/components/JsonEditor.tsx
+++ b/src/ui/components/JsonEditor.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { parse as parseJson5 } from 'json5';
 import type { ZodType } from 'zod';
 
-import './JsonEditor.css';
 
 export type JsonEditorProps = {
   initialContent: string;


### PR DESCRIPTION
## Summary
- load CSS files in the Electron window via `<link>` tags
- remove CSS imports from TSX components
- ignore compiled output in Jest configuration

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f1805d5cc83229e63b11eb0a0e5dc