### PR TITLE
Fix electron build by mapping React modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,15 @@
     <link rel="stylesheet" href="./src/ui/components/CardGrid.css" />
     <link rel="stylesheet" href="./src/ui/components/FileScanner.css" />
     <link rel="stylesheet" href="./src/ui/components/JsonEditor.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "./node_modules/react/index.js",
+          "react/jsx-runtime": "./node_modules/react/jsx-runtime.js",
+          "react-dom/client": "./node_modules/react-dom/client.js"
+        }
+      }
+    </script>
     <script type="module" src="./dist/index.js"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.5.5",
+        "@types/node": "^24.0.6",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@uiw/react-codemirror": "^4.23.13",
@@ -1972,9 +1973,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
-      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
+      "version": "24.0.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.6.tgz",
+      "integrity": "sha512-ZOyn+gOs749xU7ovp+Ibj0g1o3dFRqsfPnT22C2t5JzcRvgsEDpGawPbCISGKLudJk9Y0wiu9sYd6kUh0pc9TA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "jest",
     "test:e2e": "playwright test",
     "clean": "node -e \"import('fs').then(fs=>fs.rmSync('dist',{recursive:true,force:true}))\"",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc -p tsconfig.build.json",
     "dev": "node --loader ts-node/esm --loader ./loaders/css-loader.js src/index.ts",
     "start": "node --loader ./loaders/css-loader.js dist/index.js",
     "electron": "npm run build && electron dist/electron-main.js"
@@ -17,6 +17,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.5.5",
+    "@types/node": "^24.0.6",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@uiw/react-codemirror": "^4.23.13",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["@testing-library/jest-dom", "node"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- add import map entries for React modules in `index.html`
- compile with a dedicated `tsconfig.build.json`
- run build script with the new tsconfig
- include `jest-dom` types globally

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f216b36508322878d97bdcbc72b9e