### PR TITLE
Fix React import in Electron renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
     <script type="importmap">
       {
         "imports": {
-          "react": "./node_modules/react/index.js",
-          "react/jsx-runtime": "./node_modules/react/jsx-runtime.js",
-          "react-dom/client": "./node_modules/react-dom/client.js"
+          "react": "https://esm.sh/react",
+          "react/jsx-runtime": "https://esm.sh/react/jsx-runtime",
+          "react-dom/client": "https://esm.sh/react-dom/client"
         }
       }
     </script>


### PR DESCRIPTION
## Summary
- reference ESM versions of React packages in `index.html`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686013a7c9cc8322945d956ba9d4a713