### PR TITLE
feat: improve logging for electron module loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <link rel="stylesheet" href="./src/ui/components/JsonEditor.css" />
 
     <!-- Attempt #2: using CDN-based React imports for ESM Electron -->
+    <!-- Attempt #3: investigate missing require in renderer. Logging added in
+         node-module-loader.ts and plugin-ui-loader.ts -->
 
     <script type="importmap">
       {

--- a/src/ui/node-module-loader.ts
+++ b/src/ui/node-module-loader.ts
@@ -28,9 +28,24 @@ const getMetaUrl = (): string | undefined => {
 // throwing IIFE at import time, which caused the Electron renderer to fail
 // before it could fall back to `window.require`. By delaying the error until the
 // function is called we keep that fallback intact.
+//
+// Attempt #3 notes: when launching the UI via Electron we observed
+// `[node-module-loader] no require available at load time` followed by a runtime
+// error. To help diagnose why `require` isn't present we're now logging the
+// environment details below. These logs will remain until the root cause is
+// confirmed so future attempts don't repeat the same debugging steps.
 let nodeRequire: NodeRequire;
 console.log(
   `[node-module-loader] typeof window.require: ${typeof (globalThis as any).window?.require}`,
+);
+console.log(
+  `[node-module-loader] process.type: ${(globalThis as any).process?.type}`,
+);
+console.log(
+  `[node-module-loader] electron version: ${(globalThis as any).process?.versions?.electron}`,
+);
+console.log(
+  `[node-module-loader] typeof module.createRequire: ${typeof module?.createRequire}`,
 );
 if (typeof require === 'function') {
   console.log('[node-module-loader] using built-in require');

--- a/src/ui/plugin-ui-loader.ts
+++ b/src/ui/plugin-ui-loader.ts
@@ -1,5 +1,8 @@
 import { loadNodeModule } from './node-module-loader.js';
 const path = loadNodeModule<typeof import('path')>('path');
+// Attempt #3: previous runs failed to load plugin modules with an unclear
+// error. We now log the resolved module path before importing so we can see
+// exactly what Electron tries to load.
 import React from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
@@ -14,6 +17,7 @@ export const loadPluginUI = async (
   options: LoadPluginUiOptions,
 ): Promise<Root> => {
   const modulePath = path.join(options.pluginsPath, id, 'index.tsx');
+  console.log(`[loadPluginUI] importing ${modulePath}`);
   const mod = await import(modulePath);
   const Component = (mod.default ?? Object.values(mod).find((v) => typeof v === 'function')) as React.ComponentType | undefined;
   if (!Component) {

--- a/tests/ui/node-module-loader.test.ts
+++ b/tests/ui/node-module-loader.test.ts
@@ -20,3 +20,17 @@ it('build output does not include module specifier import', () => {
   );
   expect(js.includes("import { createRequire } from 'module'")).toBe(false);
 });
+
+it('logs environment details when require is unavailable', async () => {
+  jest.resetModules();
+  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const originalWindow = (globalThis as any).window;
+  (globalThis as any).window = {};
+  const { loadNodeModule } = await import('../../src/ui/node-module-loader.js');
+  loadNodeModule('path');
+  (globalThis as any).window = originalWindow;
+  const logs = logSpy.mock.calls.flat().join('\n');
+  expect(logs).toContain('process.type');
+  expect(logs).toContain('electron version');
+  logSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- add notes in index.html about require issue investigation
- log environment details in `node-module-loader`
- log plugin module paths before import
- test new logging behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861cd69990083229373adbe215e6587