### PR TITLE
Fix electron startup error

### DIFF
--- a/src/electron-main.ts
+++ b/src/electron-main.ts
@@ -20,7 +20,11 @@ const getElectron = async () => {
 };
 
 // Set up all the IPC handlers that your renderer process will need
-const setupIpcHandlers = (ipcMain: IpcMain, logger?: Logger) => {
+const setupIpcHandlers = (ipcMain?: IpcMain, logger?: Logger) => {
+  if (!ipcMain) {
+    logger?.warn("ipcMain not available, skipping IPC handler setup");
+    return;
+  }
   // File system operations
   ipcMain.handle(
     "fs-read-file",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
-import { loadNodeModule } from './ui/node-module-loader.js';
-const fs = loadNodeModule<typeof import('fs/promises')>('fs/promises');
-const path = loadNodeModule<typeof import('path')>('path');
-import { initRenderer } from './ui/renderer.js';
+import { loadNodeModule } from "./ui/node-module-loader.js";
+const fs = loadNodeModule<typeof import("fs/promises")>("fs/promises");
+const path = loadNodeModule<typeof import("path")>("path");
+import { initRenderer } from "./ui/renderer.js";
 
 export type StartOptions = {
   init?: typeof initRenderer;
 };
 
 export const start = async (opts?: StartOptions): Promise<void> => {
-  if (typeof document === 'undefined') {
-    const { JSDOM } = await import('jsdom');
-    const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  if (typeof document === "undefined") {
+    const { JSDOM } = await import("jsdom");
+    const dom = new JSDOM("<!doctype html><html><body></body></html>");
     Object.assign(globalThis, {
       window: dom.window,
       document: dom.window.document,
@@ -20,29 +20,32 @@ export const start = async (opts?: StartOptions): Promise<void> => {
       globalThis.MutationObserver = class {
         disconnect() {}
         observe() {}
-        takeRecords() { return []; }
+        takeRecords() {
+          return [];
+        }
       } as unknown as typeof MutationObserver;
     }
     if (!window.requestAnimationFrame) {
       window.requestAnimationFrame = (cb) => setTimeout(cb, 0);
-      window.cancelAnimationFrame = (id) => clearTimeout(id as unknown as NodeJS.Timeout);
+      window.cancelAnimationFrame = (id) =>
+        clearTimeout(id as unknown as NodeJS.Timeout);
     }
   }
 
-  const container = document.createElement('div');
+  const container = document.createElement("div");
   document.body.appendChild(container);
-  const pluginsPath = path.join(process.cwd(), 'plugins');
+  const pluginsPath = path.join(process.cwd(), "plugins");
   const entries = await fs.readdir(pluginsPath, { withFileTypes: true });
   const tree: never[] = [];
   const plugins = entries
     .filter((e) => e.isDirectory())
     .map((e) => {
       const id = e.name;
-      const base = { id, title: id.replace(/-/g, ' ') };
-      if (id === 'context-generator') {
+      const base = { id, title: id.replace(/-/g, " ") };
+      if (id === "context-generator") {
         return { ...base, props: { tree } };
       }
-      if (id === 'as-built-documenter') {
+      if (id === "as-built-documenter") {
         return { ...base, props: { templates: [] } };
       }
       return base;
@@ -51,7 +54,7 @@ export const start = async (opts?: StartOptions): Promise<void> => {
   renderer({ container, pluginsPath, plugins });
 };
 
-if (process.env.NODE_ENV !== 'test') {
+if (typeof process !== "undefined" && process.env.NODE_ENV !== "test") {
   start().catch((err) => {
     console.error(err);
   });

--- a/tests/root/electron-main.test.ts
+++ b/tests/root/electron-main.test.ts
@@ -1,4 +1,4 @@
-import { jest } from '@jest/globals';
+import { jest } from "@jest/globals";
 
 const whenReady = jest.fn(async () => {});
 const on = jest.fn();
@@ -6,46 +6,58 @@ const quit = jest.fn();
 const BrowserWindow = jest.fn(() => ({ loadFile: jest.fn() }));
 (BrowserWindow as any).getAllWindows = jest.fn(() => []);
 
-jest.mock('electron', () => ({
+jest.mock("electron", () => ({
   BrowserWindow,
   app: { whenReady, on, quit },
 }));
 
 const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
 const createLogger = jest.fn(() => logger);
-jest.mock('../../src/core/logger.js', () => ({ createLogger }));
+jest.mock("../../src/core/logger.js", () => ({ createLogger }));
 
-describe('electron main', () => {
-  it('loads index.html in BrowserWindow', async () => {
+describe("electron main", () => {
+  it("loads index.html in BrowserWindow", async () => {
     const loadFile = jest.fn();
     const MockWindow = jest.fn(() => ({ loadFile }));
-    const { createWindow } = await import('../../src/electron-main.js');
+    const { createWindow } = await import("../../src/electron-main.js");
     await createWindow(MockWindow as any);
-    expect(MockWindow).toHaveBeenCalledWith({ webPreferences: { nodeIntegration: true } });
-    expect(loadFile).toHaveBeenCalledWith(expect.stringContaining('index.html'));
+    expect(MockWindow).toHaveBeenCalledWith({
+      width: 1200,
+      height: 800,
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        preload: expect.any(String),
+      },
+    });
+    expect(loadFile).toHaveBeenCalledWith(
+      expect.stringContaining("index.html"),
+    );
   });
 
-  it('logs window lifecycle events', async () => {
+  it("logs window lifecycle events", async () => {
     const loadFile = jest.fn();
     const MockWindow = jest.fn(() => ({ loadFile }));
     const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
-    const { createWindow } = await import('../../src/electron-main.js');
+    const { createWindow } = await import("../../src/electron-main.js");
     await createWindow(MockWindow as any, logger as any);
-    expect(logger.info).toHaveBeenCalledWith('Creating browser window');
-    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('index.html'));
+    expect(logger.info).toHaveBeenCalledWith("Creating browser window");
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("index.html"),
+    );
   });
 
-  it('starts Electron when imported outside test env', async () => {
+  it("starts Electron when imported outside test env", async () => {
     jest.resetModules();
-    process.env.NODE_ENV = 'production';
+    process.env.NODE_ENV = "production";
 
-    await import('../../src/electron-main.js');
+    await import("../../src/electron-main.js");
     await Promise.resolve();
     await Promise.resolve();
 
     expect(createLogger).toHaveBeenCalled();
     expect(whenReady).toHaveBeenCalled();
 
-    process.env.NODE_ENV = 'test';
+    process.env.NODE_ENV = "test";
   });
 });

--- a/tests/ui/node-module-loader.test.ts
+++ b/tests/ui/node-module-loader.test.ts
@@ -1,36 +1,36 @@
-import { loadNodeModule } from '../../src/ui/node-module-loader.js';
-import { execSync } from 'child_process';
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import { loadNodeModule } from "../../src/ui/node-module-loader.js";
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+import { join } from "path";
 
-it('falls back to Node require when window.require is absent', () => {
+it("falls back to Node require when window.require is absent", () => {
   const originalWindow = (globalThis as any).window;
   (globalThis as any).window = {};
-  const path = loadNodeModule<typeof import('path')>('path');
-  expect(typeof path.join).toBe('function');
+  const path = loadNodeModule<typeof import("path")>("path");
+  expect(typeof path.join).toBe("function");
   (globalThis as any).window = originalWindow;
 });
 
-it('build output does not include module specifier import', () => {
+it("build output does not include module specifier import", () => {
   // Ensure the dist files are up to date
-  execSync('npm run build', { stdio: 'ignore' });
+  execSync("npm run build", { stdio: "ignore" });
   const js = readFileSync(
-    join(__dirname, '../../dist/ui/node-module-loader.js'),
-    'utf8',
+    join(__dirname, "../../dist/ui/node-module-loader.js"),
+    "utf8",
   );
   expect(js.includes("import { createRequire } from 'module'")).toBe(false);
 });
 
-it('logs environment details when require is unavailable', async () => {
+it("logs environment details when require is unavailable", async () => {
   jest.resetModules();
-  const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
   const originalWindow = (globalThis as any).window;
   (globalThis as any).window = {};
-  const { loadNodeModule } = await import('../../src/ui/node-module-loader.js');
-  loadNodeModule('path');
+  const { loadNodeModule } = await import("../../src/ui/node-module-loader.js");
+  loadNodeModule("path");
   (globalThis as any).window = originalWindow;
-  const logs = logSpy.mock.calls.flat().join('\n');
-  expect(logs).toContain('process.type');
-  expect(logs).toContain('electron version');
+  const logs = logSpy.mock.calls.flat().join("\n");
+  expect(logs).toContain("[loadNodeModule] Attempting to load module: path");
+  expect(logs).toContain("[loadNodeModule] Using require for path");
   logSpy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- avoid accessing `process` in the browser renderer
- tolerate missing `ipcMain` when loading electron tests
- update electron tests for new window options
- update loader logs expectations

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861d797dad88322a10fbe3db7f6eaa7