### PR TITLE
Fix stray variable in index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,8 +47,6 @@ export const start = async (opts?: StartOptions): Promise<void> => {
     cwd = "/";
   }
   const pluginsPath = path.join(cwd, "plugins");
-h = path.join(process.cwd(), "plugins");
-
   const entries = await fs.readdir(pluginsPath, { withFileTypes: true });
   const tree: never[] = [];
   const plugins = entries


### PR DESCRIPTION
## Summary
- remove accidental variable `h` from `src/index.ts`
- tidy up blank line after removing the variable

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686208c4f5288322bb014cb8aff8d174