### PR TITLE
Fix plugin path resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,20 +35,13 @@ export const start = async (opts?: StartOptions): Promise<void> => {
   const container = document.createElement("div");
   document.body.appendChild(container);
 
-  let cwd: string;
-  if (typeof process !== "undefined") {
-    cwd = process.cwd();
-  } else if (
-    typeof window !== "undefined" &&
-    (window as any).electronAPI?.getCwd
-  ) {
-    cwd = await (window as any).electronAPI.getCwd();
-  } else {
-    cwd = "/";
-  }
+  const cwd =
+    typeof process !== "undefined"
+      ? process.cwd()
+      : typeof window !== "undefined" && (window as any).electronAPI?.getCwd
+      ? await (window as any).electronAPI.getCwd()
+      : "/";
   const pluginsPath = path.join(cwd, "plugins");
-h = path.join(process.cwd(), "plugins");
-
   const entries = await fs.readdir(pluginsPath, { withFileTypes: true });
   const tree: never[] = [];
   const plugins = entries


### PR DESCRIPTION
## Summary
- streamline cwd resolution when determining plugin path

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686208c4f5288322bb014cb8aff8d174