### PR TITLE
Implement logging for problematic IPC arguments

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -1,27 +1,53 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
+// Utility to log when an argument cannot be cloned/serialized
+const logIfNotSerializable = (label, value) => {
+  try {
+    // structuredClone will throw if value cannot be cloned
+    structuredClone(value);
+  } catch (err) {
+    console.warn(`[preload] ${label} is not serializable`, value);
+  }
+};
+
+const safeInvoke = async (channel, ...args) => {
+  args.forEach((arg, idx) =>
+    logIfNotSerializable(`arg[${idx}] for ${channel}`, arg),
+  );
+  try {
+    return await ipcRenderer.invoke(channel, ...args);
+  } catch (err) {
+    console.error(`[preload] ipcRenderer.invoke failed for ${channel}`, err);
+    throw err;
+  }
+};
+
 // Expose protected methods that allow the renderer process to use
 // the ipcRenderer without exposing the entire object
-contextBridge.exposeInMainWorld("electronAPI", {
-  loadSampleData: (data) => ipcRenderer.invoke("load-sample-data", data),
+const electronAPI = {
+  loadSampleData: (data) => safeInvoke("load-sample-data", data),
 
   // File system operations - you'll need to implement these in main process
   readFile: (filePath, options) =>
-    ipcRenderer.invoke("fs-read-file", filePath, options),
+    safeInvoke("fs-read-file", filePath, options),
   writeFile: (filePath, data) =>
-    ipcRenderer.invoke("fs-write-file", filePath, data),
-  mkdir: (dirPath, options) => ipcRenderer.invoke("fs-mkdir", dirPath, options),
+    safeInvoke("fs-write-file", filePath, data),
+  mkdir: (dirPath, options) => safeInvoke("fs-mkdir", dirPath, options),
   readdir: (dirPath, options) =>
-    ipcRenderer.invoke("fs-readdir", dirPath, options),
+    safeInvoke("fs-readdir", dirPath, options),
 
   // Path operations
-  join: (...paths) => ipcRenderer.invoke("path-join", paths),
+  join: (...paths) => safeInvoke("path-join", paths),
 
   // Other utilities
-  getCwd: () => ipcRenderer.invoke("get-cwd"),
-});
+  getCwd: () => safeInvoke("get-cwd"),
+};
+logIfNotSerializable("electronAPI", electronAPI);
+contextBridge.exposeInMainWorld("electronAPI", electronAPI);
 
 // For backward compatibility with your existing code
-contextBridge.exposeInMainWorld("ipcRenderer", {
-  invoke: (channel, data) => ipcRenderer.invoke(channel, data),
-});
+const exposedIpc = {
+  invoke: (channel, data) => safeInvoke(channel, data),
+};
+logIfNotSerializable("ipcRenderer", exposedIpc);
+contextBridge.exposeInMainWorld("ipcRenderer", exposedIpc);

--- a/tasks/tasks-font-csp-fix.md
+++ b/tasks/tasks-font-csp-fix.md
@@ -20,7 +20,7 @@
   - [x] 1.2 Add `font-src` directive allowing `https://fonts.gstatic.com`.
   - [x] 1.3 Verify fonts load without CSP violations.
 - [ ] 4.0 Diagnose cloning error
-  - [ ] 4.1 Trace calls to Electron `ipcRenderer` or `contextBridge` for non-serializable objects.
+  - [x] 4.1 Trace calls to Electron `ipcRenderer` or `contextBridge` for non-serializable objects.
   - [ ] 4.2 Refactor any API calls to pass plain JSON-serializable data only.
   - [ ] 4.3 Add logging around `start()` to capture the failing object.
 - [ ] 5.0 Add tests

--- a/tests/core/ipc-trace.test.ts
+++ b/tests/core/ipc-trace.test.ts
@@ -1,0 +1,22 @@
+import { jest } from '@jest/globals';
+
+const exposeInMainWorld = jest.fn();
+const invoke = jest.fn(async () => {});
+
+jest.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld },
+  ipcRenderer: { invoke },
+}));
+
+it('logs warning for non-serializable arguments', async () => {
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  // @ts-ignore importing commonjs module without types
+  await import('../../src/preload.js');
+  const electronApi = (
+    exposeInMainWorld.mock.calls.find((c) => c[0] === 'electronAPI')?.[1]
+  ) as any;
+  const nonSerializable = { fn: () => {} } as any;
+  await electronApi.readFile(nonSerializable, {});
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('arg[0] for fs-read-file'), nonSerializable);
+  warnSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- log warnings when non-serializable objects are passed over IPC
- expose helper `safeInvoke` in preload script and trace IPC calls
- test warning behaviour for unsafe arguments
- mark subtask 4.1 as complete in font/csp task list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862aad8d1608322beb089d40ed49cac