### PR TITLE
Implement logging for structured cloning error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export type StartOptions = {
 };
 
 export const start = async (opts?: StartOptions): Promise<void> => {
+  try {
   if (typeof document === "undefined") {
     const { JSDOM } = await import("jsdom");
     const dom = new JSDOM("<!doctype html><html><body></body></html>");
@@ -59,6 +60,10 @@ export const start = async (opts?: StartOptions): Promise<void> => {
     });
   const renderer = opts?.init ?? initRenderer;
   renderer({ container, pluginsPath, plugins });
+  } catch (err) {
+    console.error('[start] failed', { options: opts }, err);
+    throw err;
+  }
 };
 
 if (typeof process !== "undefined" && process.env.NODE_ENV !== "test") {

--- a/tasks/tasks-font-csp-fix.md
+++ b/tasks/tasks-font-csp-fix.md
@@ -6,6 +6,8 @@
 - `src/ui/components/JsonEditor.css` - Uses Nunito Sans font-family.
 - `src/preload.js` - Exposes Electron APIs to renderer; may cause cloning errors.
 - `tests/core/ipc-sanitize.test.ts` - Verifies arguments are sanitized before IPC.
+- `src/index.ts` - Application startup logic.
+- `tests/root/startup.test.ts` - Tests startup behavior.
 
 ### Notes
 
@@ -23,7 +25,7 @@
 - [ ] 4.0 Diagnose cloning error
   - [x] 4.1 Trace calls to Electron `ipcRenderer` or `contextBridge` for non-serializable objects.
   - [x] 4.2 Refactor any API calls to pass plain JSON-serializable data only.
-  - [ ] 4.3 Add logging around `start()` to capture the failing object.
+  - [x] 4.3 Add logging around `start()` to capture the failing object.
 - [ ] 5.0 Add tests
   - [ ] 5.1 Write a test ensuring the application starts without the cloning error.
   - [x] 5.2 Write a test verifying the fonts load successfully under the chosen approach.

--- a/tests/root/startup.test.ts
+++ b/tests/root/startup.test.ts
@@ -4,9 +4,32 @@ jest.unstable_mockModule('../../src/ui/renderer.js', () => ({
   initRenderer: jest.fn(),
 }));
 
+beforeEach(() => {
+  jest.resetModules();
+});
+
 it('calls initRenderer with discovered plugins', async () => {
   const { start } = await import('../../src/index.js');
   const mockInit = jest.fn();
   await start({ init: mockInit as any });
   expect(mockInit).toHaveBeenCalled();
+});
+
+it('logs options when start fails', async () => {
+  jest.unstable_mockModule('../../src/ui/renderer.js', () => ({
+    initRenderer: () => {
+      throw new Error('boom');
+    },
+  }));
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const { start } = await import('../../src/index.js');
+  const failingInit = () => {
+    throw new Error('boom');
+  };
+  await expect(start({ init: failingInit as any })).rejects.toThrow('boom');
+  const call = consoleSpy.mock.calls.find((c) => c[0] === '[start] failed');
+  expect(call).toBeDefined();
+  expect(call?.[1]).toEqual(expect.objectContaining({ options: expect.anything() }));
+  expect(call?.[2]).toBeInstanceOf(Error);
+  consoleSpy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- log start options when initialization fails
- test the new logging behavior
- update task list for cloning error diagnosis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862b4fee820832291daff5afc3f1b9e