### PR TITLE
Fix Electron startup path handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export const start = async (opts?: StartOptions): Promise<void> => {
       : typeof window !== "undefined" && (window as any).electronAPI?.getCwd
       ? await (window as any).electronAPI.getCwd()
       : "/";
-  const pluginsPath = path.join(cwd, "plugins");
+  const pluginsPath = await path.join(cwd, "plugins");
   const entries = await fs.readdir(pluginsPath, { withFileTypes: true });
   const tree: never[] = [];
   const plugins = entries

--- a/src/ui/plugin-ui-loader.ts
+++ b/src/ui/plugin-ui-loader.ts
@@ -16,7 +16,7 @@ export const loadPluginUI = async (
   id: string,
   options: LoadPluginUiOptions,
 ): Promise<Root> => {
-  const modulePath = path.join(options.pluginsPath, id, 'index.tsx');
+  const modulePath = await path.join(options.pluginsPath, id, 'index.tsx');
   console.log(`[loadPluginUI] importing ${modulePath}`);
   const mod = await import(modulePath);
   const Component = (mod.default ?? Object.values(mod).find((v) => typeof v === 'function')) as React.ComponentType | undefined;

--- a/tests/root/startup-async-path.test.ts
+++ b/tests/root/startup-async-path.test.ts
@@ -1,0 +1,19 @@
+import { jest } from '@jest/globals';
+import fs from 'fs/promises';
+import path from 'path';
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+test('start resolves when path.join returns a Promise', async () => {
+  const electronAPI = {
+    readdir: async (dirPath: string, options?: any) => fs.readdir(dirPath, options),
+    join: async (...parts: string[]) => path.join(...parts),
+    getCwd: async () => process.cwd(),
+  };
+  (window as any).electronAPI = electronAPI;
+  const { start } = await import('../../src/index.js');
+  await expect(start()).resolves.not.toThrow();
+  delete (window as any).electronAPI;
+});

--- a/troubleshooting/ElectronStartupIssue.md
+++ b/troubleshooting/ElectronStartupIssue.md
@@ -20,3 +20,7 @@ ipcRenderer.invoke failed for fs-readdir Error: Error invoking remote method 'fs
 ---
 
 Before making code changes, confirm which argument is sent to `fs.readdir`. Logging the value just before invoking `electronAPI.readdir` can reveal whether a non-string object is being passed.
+
+## Troubleshooting Attempts
+- Updated renderer code to await `path.join` calls so a string is passed to `fs.readdir`. This should resolve "Non-string path argument" errors on startup.
+


### PR DESCRIPTION
## Summary
- await `path.join` so fs functions get strings
- await module path join when loading plugins
- note attempted fix in ElectronStartupIssue docs
- test startup with async `path.join`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862bd31efec8322982ecc76531f0d41