### PR TITLE
Update loader to use fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 This will be an evolution of the ttComander application
 
 The project runs entirely in a standard Node environment using an Express server.
+The server exposes a simple file system API:
+
+- `GET /api/read?path=FILE`
+- `POST /api/write?path=FILE` with `{ data: string }`
+- `GET /api/readdir?path=DIR&withFileTypes=true`
+- `POST /api/mkdir?path=DIR` with `{ options?: object }`
 
 ## Contributing
 

--- a/tasks/tasks-removeelectron.md
+++ b/tasks/tasks-removeelectron.md
@@ -4,7 +4,7 @@
 - `src/electron-main.ts` – Starts the Electron app and sets up IPC handlers.​:codex-file-citation[codex-file-citation]{line_range_start=1 line_range_end=20 path=src/electron-main.ts git_url="https://github.com/dustywill/Omnia/blob/main/src/electron-main.ts#L1-L20"}​
 - `src/preload.js` – Exposes Electron APIs to the renderer process.​:codex-file-citation[codex-file-citation]{line_range_start=1 line_range_end=33 path=src/preload.js git_url="https://github.com/dustywill/Omnia/blob/main/src/preload.js#L1-L33"}​
 - `src/index.ts` – Application startup logic that checks for `electronAPI`.​:codex-file-citation[codex-file-citation]{line_range_start=12 line_range_end=44 path=src/index.ts git_url="https://github.com/dustywill/Omnia/blob/main/src/index.ts#L12-L44"}​
-- `src/ui/node-module-loader.ts` – Provides Node module access through Electron IPC.​:codex-file-citation[codex-file-citation]{line_range_start=8 line_range_end=35 path=src/ui/node-module-loader.ts git_url="https://github.com/dustywill/Omnia/blob/main/src/ui/node-module-loader.ts#L8-L35"}​
+ - `src/ui/node-module-loader.ts` – Provides Node module access via fetch calls to the Express API.​:codex-file-citation[codex-file-citation]{line_range_start=8 line_range_end=35 path=src/ui/node-module-loader.ts git_url="https://github.com/dustywill/Omnia/blob/main/src/ui/node-module-loader.ts#L8-L35"}​
 - `index.html` – Loads the application and references Electron APIs.​:codex-file-citation[codex-file-citation]{line_range_start=9 line_range_end=23 path=index.html git_url="https://github.com/dustywill/Omnia/blob/main/index.html#L9-L23"}​
 - `tests/root/electron-main.test.ts` – Tests specific to Electron startup. **Deleted.**
 - `tests/root/startup-clone.test.ts` – Relies on Electron mocks. **Deleted.**
@@ -33,7 +33,7 @@
 - [ ] 2.0 Replace IPC file access with a web API
 
   - [x] 2.1 Implement a small Express server in `src/server.ts` exposing file system endpoints (read, write, readdir, etc.). The server should also serve `index.html` and compiled assets from `dist`.
-  - [ ] 2.2 Modify `src/ui/node-module-loader.ts` to call these endpoints using `fetch`.
+  - [x] 2.2 Modify `src/ui/node-module-loader.ts` to call these endpoints using `fetch`.
   - [ ] 2.3 Update plugins and core modules to use the new API instead of Electron IPC.
   - [x] 2.4 Update the `start` script to launch the Express server and open the application.
 

--- a/tests/plugins/as-built-documenter.test.tsx
+++ b/tests/plugins/as-built-documenter.test.tsx
@@ -5,6 +5,11 @@ import path from 'path';
 import { AsBuiltDocumenter } from '../../plugins/as-built-documenter/index.js';
 
 describe('as-built documenter plugin', () => {
+  beforeEach(() => {
+    // force Node require path in node-module-loader
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = undefined;
+  });
   it('lists Markdown templates in dropdown and allows clearing', async () => {
     render(<AsBuiltDocumenter templates={['one.md', 'two.md']} />);
 

--- a/tests/plugins/context-generator.test.tsx
+++ b/tests/plugins/context-generator.test.tsx
@@ -6,6 +6,11 @@ import type { FileNode } from '../../src/ui/components/FileScanner.js';
 import { ContextGenerator } from '../../plugins/context-generator/index.js';
 
 describe('context generator plugin', () => {
+  beforeEach(() => {
+    // force loadNodeModule to use Node require
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = undefined;
+  });
   it('uses FileScanner to choose files', async () => {
     const tree: FileNode[] = [
       {

--- a/tests/plugins/customer-links.test.tsx
+++ b/tests/plugins/customer-links.test.tsx
@@ -15,6 +15,9 @@ describe('customer links plugin', () => {
   const jsonPath = path.join(dir, 'customers.json5');
 
   beforeEach(async () => {
+    // ensure Node require path is used
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).fetch = undefined;
     await fs.rm(dir, { recursive: true, force: true });
     await fs.mkdir(dir, { recursive: true });
     const content = `[

--- a/tests/server/server.test.ts
+++ b/tests/server/server.test.ts
@@ -27,4 +27,21 @@ describe('server', () => {
     expect(res.status).toBe(200);
     expect(res.text).toBe('hello');
   });
+
+  it('creates directories', async () => {
+    const res = await request(app).post('/api/mkdir').query({ path: 'dir' }).send({ options: { recursive: true } });
+    expect(res.status).toBe(204);
+    const stat = await fs.stat(path.join(tmpDir, 'dir'));
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('lists directory entries with file types', async () => {
+    await fs.mkdir(path.join(tmpDir, 'dir2'));
+    await fs.writeFile(path.join(tmpDir, 'dir2', 'file.txt'), 'x');
+    const res = await request(app)
+      .get('/api/readdir')
+      .query({ path: 'dir2', withFileTypes: 'true' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ name: 'file.txt', isDirectory: false }]);
+  });
 });


### PR DESCRIPTION
## Summary
- switch node-module-loader to use fetch-based API
- expand server endpoints for mkdir and readdir
- adjust tests for browserless runtime
- document API endpoints in README
- mark loader update task complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862cf72423c8322b5c503dd2179d13d