### PR TITLE
Build plugins with tsc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ system API:
 ## Plugins
 
 Plugins are React components located in the `plugins/` directory. Each plugin is
-loaded at runtime and uses the helpers from `src/ui/node-module-loader.ts` to
-access the file system via the API endpoints above. This allows browser-based
-plugins to read and write files through the Express server.
+compiled to JavaScript as part of the build process and loaded at runtime from
+`dist/plugins/<plugin-id>/index.js`. The helpers in
+`src/ui/node-module-loader.ts` allow these browser based plugins to read and
+write files through the Express server's API endpoints.
 
 ## Contributing
 
@@ -29,5 +30,5 @@ plugins to read and write files through the Express server.
 
 1. Install dependencies with `npm install`.
 2. Start the app in development mode using `npm run dev`.
-3. Build the project with `npm run build`.
+3. Build the project with `npm run build`. This compiles the server and all plugins to the `dist/` directory.
 4. Run the compiled app using `npm start`. This launches the Express server and automatically opens `http://localhost:3000` in your default browser.

--- a/plugins/customer-links/index.tsx
+++ b/plugins/customer-links/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { loadNodeModule } from '../../src/ui/node-module-loader.js';
 const fs = loadNodeModule<typeof import('fs/promises')>('fs/promises');
 const path = loadNodeModule<typeof import('path')>('path');
-import { openJsonEditor } from '../../src/ui/json-editor-api';
+import { openJsonEditor } from '../../src/ui/json-editor-api.js';
 import { parse as parseJson5 } from 'json5';
 import { z } from 'zod';
 

--- a/src/ui/plugin-ui-loader.ts
+++ b/src/ui/plugin-ui-loader.ts
@@ -16,9 +16,18 @@ export const loadPluginUI = async (
   id: string,
   options: LoadPluginUiOptions,
 ): Promise<Root> => {
-  const modulePath = path.join(options.pluginsPath, id, 'index.tsx');
-  console.log(`[loadPluginUI] importing ${modulePath}`);
-  const mod = await import(modulePath);
+  const jsPath = path.join(options.pluginsPath, id, 'index.js');
+  const tsPath = path.join(options.pluginsPath, id, 'index.tsx');
+  let modulePath = jsPath;
+  let mod: Record<string, unknown>;
+  try {
+    console.log(`[loadPluginUI] importing ${modulePath}`);
+    mod = await import(modulePath);
+  } catch {
+    modulePath = tsPath;
+    console.log(`[loadPluginUI] importing ${modulePath}`);
+    mod = await import(modulePath);
+  }
   const Component = (mod.default ?? Object.values(mod).find((v) => typeof v === 'function')) as React.ComponentType | undefined;
   if (!Component) {
     throw new Error(`No component export found for plugin ${id}`);

--- a/tests/ui/node-module-loader.test.ts
+++ b/tests/ui/node-module-loader.test.ts
@@ -18,7 +18,7 @@ it("build output does not include module specifier import", () => {
   // Ensure the dist files are up to date
   execSync("npm run build", { stdio: "ignore" });
   const js = readFileSync(
-    join(__dirname, "../../dist/ui/node-module-loader.js"),
+    join(__dirname, "../../dist/src/ui/node-module-loader.js"),
     "utf8",
   );
   expect(js.includes("import { createRequire } from 'module'")).toBe(false);

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "jsx": "react"
-  }
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*", "plugins/**/*"]
 }


### PR DESCRIPTION
## Summary
- compile plugin sources alongside app
- load compiled `index.js` files with fallback to TypeScript sources
- fix plugin import paths for NodeNext
- update build test with new output location
- document plugin build output in README

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862f8c332e883228cfe64f12238f518