### PR TITLE
Add UI screenshot test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "node scripts/test-with-log.js",
     "test:only": "node --experimental-vm-modules ./node_modules/.bin/jest",
     "test:e2e": "playwright test",
+    "test:ui": "playwright test",
     "clean": "node -e \"import('fs').then(fs=>fs.rmSync('dist',{recursive:true,force:true}))\"",
     "build": "npm run clean && tsc -p tsconfig.build.json && tsc -p tsconfig.plugins.json && node scripts/copy-assets.js && node scripts/process-css-modules.js && node scripts/fix-plugin-imports.js",
     "electron": "npm run build && electron dist/electron-main.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,4 +2,10 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: 'tests/e2e',
+  testMatch: /ui-screens\.spec\.ts/,
+  timeout: 60_000,
+  use: {
+    headless: true,
+  },
+  reporter: [['list'], ['html', { outputFolder: 'playwright-report' }]],
 });

--- a/tests/e2e/ui-screens.spec.ts
+++ b/tests/e2e/ui-screens.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const OUTPUT_DIR = path.join(__dirname, '../output');
+
+// Ensure the output directory exists
+if (!fs.existsSync(OUTPUT_DIR)) {
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+}
+
+/** Utility to grab computed styles for the app container */
+async function getAppStyles(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector('#app') as HTMLElement;
+    if (!el) return {};
+    const computed = window.getComputedStyle(el);
+    return Array.from(computed).reduce<Record<string, string>>((acc, prop) => {
+      acc[prop] = computed.getPropertyValue(prop);
+      return acc;
+    }, {});
+  });
+}
+
+test.describe('UI Screenshots', () => {
+  test('capture screenshots and styles for each navigation view', async ({ page }) => {
+    const indexPath = path.join(__dirname, '../../index.html');
+    await page.goto('file://' + indexPath);
+
+    const navLabels = ['Dashboard', 'Plugins', 'Settings', 'Logs'];
+    for (const label of navLabels) {
+      if (label !== 'Dashboard') {
+        await page.getByText(label, { exact: true }).click();
+      }
+      // Wait briefly for view transition
+      await page.waitForTimeout(500);
+      const base = label.toLowerCase();
+      const screenshotPath = path.join(OUTPUT_DIR, `${base}.png`);
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      const styles = await getAppStyles(page);
+      fs.writeFileSync(
+        path.join(OUTPUT_DIR, `${base}.json`),
+        JSON.stringify(styles, null, 2)
+      );
+    }
+
+    // Simple assertion: ensure last view text is visible
+    await expect(page.getByText('Logs')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add `test:ui` script and Playwright config
- implement UI screenshot capture test

## Testing
- `npm run test:e2e` *(fails: locator.click timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686a01463ac48322823674e3dd2e169e