### PR TITLE
fix: build app before e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   testDir: 'tests/e2e',
   testMatch: /ui-screens\.spec\.ts/,
   timeout: 60_000,
+  globalSetup: './tests/e2e/global-setup.ts',
   use: {
     headless: true,
   },

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,5 @@
+import { execSync } from 'child_process';
+
+export default async () => {
+  execSync('npm run build', { stdio: 'inherit' });
+};


### PR DESCRIPTION
## Summary
- run `npm run build` before executing Playwright tests

## Testing
- `npm install`
- `npm run build` *(fails: src/core/logger.ts 'originalConsole' is declared but its value is never read)*

------
https://chatgpt.com/codex/tasks/task_e_686a0c843cd08322b46b371f2635ebfd