### PR TITLE
Add visual regression scaffolding and button tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+tests/snapshots/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
   globalSetup: './tests/e2e/global-setup.ts',
   use: {
     headless: true,
+    trace: 'on-first-retry',
   },
   reporter: [['list'], ['html', { outputFolder: 'playwright-report' }]],
+  projects: [{ name: 'Electron App' }],
 });

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -1,0 +1,26 @@
+import { test } from '@playwright/test';
+import path from 'path';
+import { findElements } from '../lib/UIElementScanner.js';
+import { captureSnapshot, compareSnapshots } from '../lib/SnapshotManager.js';
+
+test.describe('Visual regression', () => {
+  test('scan and capture element snapshots', async ({ page }, testInfo) => {
+    const indexPath = path.join(testInfo.config.rootDir, 'index.html');
+    await page.goto('file://' + indexPath);
+
+    const elements = findElements(page);
+    for (const locator of elements) {
+      await captureSnapshot(locator, 'default', testInfo);
+    }
+  });
+
+  test('compare against baseline', async ({ page }, testInfo) => {
+    const indexPath = path.join(testInfo.config.rootDir, 'index.html');
+    await page.goto('file://' + indexPath);
+
+    const elements = findElements(page);
+    for (const locator of elements) {
+      await compareSnapshots(locator, 'default', testInfo);
+    }
+  });
+});

--- a/tests/lib/SnapshotManager.ts
+++ b/tests/lib/SnapshotManager.ts
@@ -1,0 +1,47 @@
+import { Locator, expect, TestInfo } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const SNAPSHOT_DIR = path.resolve('tests/snapshots');
+
+export const captureSnapshot = async (
+  locator: Locator,
+  state: string,
+  testInfo: TestInfo
+) => {
+  const elementId = await locator.evaluate((el) => el.id || el.outerHTML);
+  const dir = path.join(SNAPSHOT_DIR, testInfo.title.replace(/\s+/g, '_'));
+  fs.mkdirSync(dir, { recursive: true });
+  const css = await locator.evaluate((el) => {
+    const styles = window.getComputedStyle(el as HTMLElement);
+    return JSON.stringify(
+      Array.from(styles).reduce<Record<string, string>>((acc, prop) => {
+        acc[prop] = styles.getPropertyValue(prop);
+        return acc;
+      }, {})
+    );
+  });
+  fs.writeFileSync(path.join(dir, `${elementId}-${state}.json`), css);
+  await locator.screenshot({ path: path.join(dir, `${elementId}-${state}.png`) });
+};
+
+export const compareSnapshots = async (
+  locator: Locator,
+  state: string,
+  testInfo: TestInfo
+) => {
+  const elementId = await locator.evaluate((el) => el.id || el.outerHTML);
+  const dir = path.join(SNAPSHOT_DIR, testInfo.title.replace(/\s+/g, '_'));
+  await expect(locator).toHaveScreenshot(`${elementId}-${state}.png`);
+  const baseline = JSON.parse(
+    fs.readFileSync(path.join(dir, `${elementId}-${state}.json`), 'utf-8')
+  );
+  const current = await locator.evaluate((el) => {
+    const styles = window.getComputedStyle(el as HTMLElement);
+    return Array.from(styles).reduce<Record<string, string>>((acc, prop) => {
+      acc[prop] = styles.getPropertyValue(prop);
+      return acc;
+    }, {});
+  });
+  expect(current).toEqual(baseline);
+};

--- a/tests/lib/UIElementScanner.ts
+++ b/tests/lib/UIElementScanner.ts
@@ -1,0 +1,6 @@
+import { Locator, Page } from '@playwright/test';
+
+export const findElements = (page: Page): Locator[] => {
+  const selectors = 'button, a, input, [role="button"], [data-testid]';
+  return page.locator(selectors).all();
+};

--- a/tests/ui/components/Button.test.tsx
+++ b/tests/ui/components/Button.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Button } from '../../../src/ui/components/Button/Button.js';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<Button onClick={onClick}>Press</Button>);
+    fireEvent.click(screen.getByRole('button', { name: 'Press' }));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('applies variant and size classes', () => {
+    render(
+      <Button variant="secondary" size="lg">Test</Button>
+    );
+    const btn = screen.getByRole('button', { name: 'Test' });
+    expect(btn.className).toContain('bg-neutral-80');
+    expect(btn.className).toContain('px-6');
+  });
+
+  it('does not trigger click when disabled', () => {
+    const onClick = jest.fn();
+    render(
+      <Button onClick={onClick} disabled>Disabled</Button>
+    );
+    const btn = screen.getByRole('button', { name: 'Disabled' });
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('includes hover and focus classes', () => {
+    render(<Button>Hover</Button>);
+    const btn = screen.getByRole('button', { name: 'Hover' });
+    expect(btn.className).toMatch(/hover:/);
+    expect(btn.className).toMatch(/focus:/);
+  });
+});


### PR DESCRIPTION
## Summary
- update Playwright config with trace and project name
- store snapshots outside repo
- add Playwright helpers for element scanning and snapshot comparison
- start a visual-regression spec using the helpers
- add basic tests for the Button component

## Testing
- `npm test` *(fails: PluginManifestSchema and others fail)*

------
https://chatgpt.com/codex/tasks/task_e_686adcb7139483229b185898ecf3c60d