### PR TITLE
Add Input component tests

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -35,11 +35,14 @@ global.Range.prototype.getBoundingClientRect = function() {
 if (!global.navigator.clipboard) {
   Object.defineProperty(global.navigator, 'clipboard', {
     value: {
-      writeText: function() { return Promise.resolve(); },
+      writeText: () => Promise.resolve(),
+      readText: () => Promise.resolve(''),
     },
     configurable: true,
     writable: true,
   });
+} else if (typeof global.navigator.clipboard.readText !== 'function') {
+  global.navigator.clipboard.readText = () => Promise.resolve('');
 }
 
 // Utility for path resolution in tests

--- a/tests/ui/components/Input.test.tsx
+++ b/tests/ui/components/Input.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Input } from '../../../src/ui/components/Input/Input.js';
+
+describe('Input', () => {
+  it('renders label and helper text', () => {
+    render(<Input label="Email" helperText="Enter email" />);
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Enter email')).toBeInTheDocument();
+  });
+
+  it('accepts typing', async () => {
+    const user = userEvent.setup();
+    render(<Input label="Name" />);
+    const input = screen.getByLabelText('Name');
+    await user.type(input, 'John');
+    expect((input as HTMLInputElement).value).toBe('John');
+  });
+
+  it('shows error state styling', () => {
+    render(<Input label="Password" error="Required" />);
+    const input = screen.getByLabelText('Password');
+    expect(input.className).toContain('border-danger');
+    expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+
+  it('renders icon', () => {
+    render(<Input label="Search" icon={<span data-testid="icon">i</span>} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('generates id and associates label', () => {
+    render(<Input label="Test" />);
+    const input = screen.getByLabelText('Test');
+    const label = screen.getByText('Test');
+    expect(input.id).toMatch(/^input-/);
+    expect(label).toHaveAttribute('for', input.id);
+  });
+
+  it('focuses input when label clicked', async () => {
+    const user = userEvent.setup();
+    render(<Input label="Username" />);
+    const label = screen.getByText('Username');
+    const input = screen.getByLabelText('Username');
+    await user.click(label);
+    expect(document.activeElement).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
- implement Jest tests for Input component covering label, helper text, typing, error styling, icon rendering, autogenerated IDs and focus behaviour
- extend clipboard mock in test setup with `readText`

## Testing
- `node --experimental-vm-modules ./node_modules/.bin/jest tests/ui/components/Input.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_686b0cba1d4c8322bd45a48696cda58d