### PR TITLE
Add layout component tests

### DIFF
--- a/TESTING_IMPLEMENTATION_CHECKLIST.md
+++ b/TESTING_IMPLEMENTATION_CHECKLIST.md
@@ -58,11 +58,11 @@ This section covers the setup of the AI-driven Playwright testing framework.
 This section covers tasks from `docs/testing/UI_COMPONENT_TEST_PLAN.md`.
 
 ### 2.1: Review and Audit Existing Tests
-- [ ] **Audit Primitive Components:**
-  - [ ] Review tests for `Button` in `tests/ui/components/`. (Missing: No `Button.test.tsx` found)
-  - [ ] Review tests for `Input`. (Missing: No `Input.test.tsx` found)
-  - [ ] Review tests for `Badge`. (Missing: No `Badge.test.tsx` found)
-  - [ ] Review tests for `ToggleSwitch`. (Missing: No `ToggleSwitch.test.tsx` found)
+[X] **Audit Primitive Components:**
+- [X] Review tests for `Button` in `tests/ui/components/`. (Completed)
+  - [X] Review tests for `Input`. (Completed)
+  - [X] Review tests for `Badge`. (Completed)
+  - [X] Review tests for `ToggleSwitch`. (Completed)
 - [ ] **Audit Layout Components:**
   - [ ] Review tests for `Card`. (Missing: No `Card.test.tsx` found)
   - [ ] Review tests for `Grid`. (Missing: No `Grid.test.tsx` found)
@@ -88,48 +88,48 @@ This section covers tasks from `docs/testing/UI_COMPONENT_TEST_PLAN.md`.
   - [ ] If applicable, update the component to make the test pass.
   - [ ] Refactor the tests for clarity and ensure all conditions from the component matrix are met.
 
-- [ ] **Implement `Button` Tests (`tests/ui/components/Button.test.tsx`):**
-  - [ ] Renders text/children.
-  - [ ] Calls `onClick` when clicked.
-  - [ ] Applies variants & sizes.
-  - [ ] Disabled state prevents clicks.
-  - [ ] Hover/focus classes are added.
+- [X] **Implement `Button` Tests (`tests/ui/components/Button.test.tsx`):**
+  - [X] Renders text/children.
+  - [X] Calls `onClick` when clicked.
+  - [X] Applies variants & sizes.
+  - [X] Disabled state prevents clicks.
+  - [X] Hover/focus classes are added.
 
-- [ ] **Implement `Input` Tests (`tests/ui/components/Input.test.tsx`):**
-  - [ ] Renders label and helper text.
-  - [ ] Accepts typing.
-  - [ ] Error state styling.
-  - [ ] Icon rendering.
-  - [ ] Generates unique `id`.
-  - [ ] Focus management.
+- [X] **Implement `Input` Tests (`tests/ui/components/Input.test.tsx`):**
+  - [X] Renders label and helper text.
+  - [X] Accepts typing.
+  - [X] Error state styling.
+  - [X] Icon rendering.
+  - [X] Generates unique `id`.
+  - [X] Focus management.
 
-- [ ] **Implement `Badge` Tests (`tests/ui/components/Badge.test.tsx`):**
-  - [ ] Displays children.
-  - [ ] Variant colours.
-  - [ ] Size options.
+- [X] **Implement `Badge` Tests (`tests/ui/components/Badge.test.tsx`):**
+  - [X] Displays children.
+  - [X] Variant colours.
+  - [X] Size options.
 
-- [ ] **Implement `ToggleSwitch` Tests (`tests/ui/components/ToggleSwitch.test.tsx`):**
-  - [ ] Toggles checked state on click.
-  - [ ] Calls `onChange`.
-  - [ ] Keyboard activation.
-  - [ ] Disabled state.
+- [X] **Implement `ToggleSwitch` Tests (`tests/ui/components/ToggleSwitch.test.tsx`):**
+  - [X] Toggles checked state on click.
+  - [X] Calls `onChange`.
+  - [X] Keyboard activation.
+  - [X] Disabled state.
 
 - [ ] **Implement `Card` Tests (`tests/ui/components/Card.test.tsx`):**
-  - [ ] Renders children.
-  - [ ] `onClick` invoked when interactive.
-  - [ ] Elevation & hover classes applied when `elevated`/`interactive`.
-  - [ ] Respects custom className.
+  - [X] Renders children.
+  - [X] `onClick` invoked when interactive.
+  - [X] Elevation & hover classes applied when `elevated`/`interactive`.
+  - [X] Respects custom className.
 
-- [ ] **Implement `Grid` Tests (`tests/ui/components/Grid.test.tsx`):**
-  - [ ] Creates correct column count.
-  - [ ] Gap sizes.
-  - [ ] Responsive className passthrough.
+- [X] **Implement `Grid` Tests (`tests/ui/components/Grid.test.tsx`):**
+  - [X] Creates correct column count.
+  - [X] Gap sizes.
+  - [X] Responsive className passthrough.
 
 - [ ] **Implement `Sidebar` & `SidebarItem` Tests (`tests/ui/components/Sidebar.test.tsx`, `SidebarItem.test.tsx`):**
   - [ ] Collapse/expand behaviour.
-  - [ ] Item click callbacks.
-  - [ ] Active item highlighting.
-  - [ ] Icon rendering.
+  - [X] Item click callbacks.
+  - [X] Active item highlighting.
+  - [X] Icon rendering.
 
 - [ ] **Enhance `CardGrid` Tests (`tests/ui/components/CardGrid.test.tsx`):**
   - [ ] Verify `Card` specific behaviors (e.g., `onClick` for interactive cards, elevation/hover classes).

--- a/src/ui/components/Card/Card.tsx
+++ b/src/ui/components/Card/Card.tsx
@@ -7,6 +7,7 @@ export interface CardProps {
   elevated?: boolean;
   interactive?: boolean;
   padding?: 'none' | 'sm' | 'md' | 'lg';
+  onClick?: () => void;
 }
 
 export function Card({ 
@@ -14,7 +15,8 @@ export function Card({
   className = '', 
   elevated = false, 
   interactive = false,
-  padding = 'md'
+  padding = 'md',
+  onClick
 }: CardProps) {
   const paddingClasses = {
     none: '',
@@ -27,8 +29,13 @@ export function Card({
   const elevatedClasses = elevated ? 'shadow-lg' : '';
   const interactiveClasses = interactive ? styles.interactive : '';
   
+  const clickHandler = interactive ? onClick : undefined;
+
   return (
-    <div className={`${baseClasses} ${elevatedClasses} ${interactiveClasses} ${styles.card} ${className}`}>
+    <div
+      className={`${baseClasses} ${elevatedClasses} ${interactiveClasses} ${styles.card} ${className}`}
+      onClick={clickHandler}
+    >
       {children}
     </div>
   );

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -35,11 +35,14 @@ global.Range.prototype.getBoundingClientRect = function() {
 if (!global.navigator.clipboard) {
   Object.defineProperty(global.navigator, 'clipboard', {
     value: {
-      writeText: function() { return Promise.resolve(); },
+      writeText: () => Promise.resolve(),
+      readText: () => Promise.resolve(''),
     },
     configurable: true,
     writable: true,
   });
+} else if (typeof global.navigator.clipboard.readText !== 'function') {
+  global.navigator.clipboard.readText = () => Promise.resolve('');
 }
 
 // Utility for path resolution in tests

--- a/tests/style-mock.js
+++ b/tests/style-mock.js
@@ -1,1 +1,3 @@
-module.exports = {};
+export default new Proxy({}, {
+  get: (_, prop) => (typeof prop === 'string' ? prop : ''),
+});

--- a/tests/ui/components/Badge.test.tsx
+++ b/tests/ui/components/Badge.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { Badge } from '../../../src/ui/components/Badge/Badge.js';
+
+describe('Badge', () => {
+  it('displays children', () => {
+    render(<Badge>New</Badge>);
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('applies variant colours', () => {
+    render(<Badge variant="primary">Color</Badge>);
+    const badge = screen.getByText('Color');
+    expect(badge.className).toContain('bg-blue-95');
+  });
+
+  it('applies size options', () => {
+    render(<Badge size="lg">Large</Badge>);
+    const badge = screen.getByText('Large');
+    expect(badge.className).toContain('py-1.5');
+  });
+});

--- a/tests/ui/components/Button.test.tsx
+++ b/tests/ui/components/Button.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { jest } from '@jest/globals';
 import { Button } from '../../../src/ui/components/Button/Button.js';
 
 describe('Button', () => {

--- a/tests/ui/components/Card.test.tsx
+++ b/tests/ui/components/Card.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { jest } from '@jest/globals';
+import { Card } from '../../../src/ui/components/Card/Card.js';
+
+describe('Card', () => {
+  it('renders children', () => {
+    const { container } = render(<Card>content</Card>);
+    expect(container.firstChild?.textContent).toBe('content');
+  });
+
+  it('applies elevated and interactive classes', () => {
+    const { container } = render(<Card elevated interactive>text</Card>);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain('shadow-lg');
+    expect(card.className).toContain('interactive');
+  });
+
+  it('invokes onClick when interactive', async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+    const { container } = render(<Card interactive onClick={onClick}>text</Card>);
+    await user.click(container.firstElementChild as HTMLElement);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<Card className="custom">x</Card>);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card).toHaveClass('custom');
+  });
+});

--- a/tests/ui/components/Grid.test.tsx
+++ b/tests/ui/components/Grid.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import { Grid } from '../../../src/ui/components/Grid/Grid.js';
+
+describe('Grid', () => {
+  it('creates correct column count', () => {
+    const { container } = render(<Grid cols={4}><div>1</div></Grid>);
+    const grid = container.firstElementChild as HTMLElement;
+    expect(grid.className).toContain('lg:grid-cols-4');
+  });
+
+  it('applies gap sizes', () => {
+    const { container } = render(<Grid gap="lg"><div>1</div></Grid>);
+    const grid = container.firstElementChild as HTMLElement;
+    expect(grid.className).toContain('gap-8');
+  });
+
+  it('passes custom className', () => {
+    const { container } = render(<Grid className="custom"><div>1</div></Grid>);
+    const grid = container.firstElementChild as HTMLElement;
+    expect(grid).toHaveClass('custom');
+  });
+});

--- a/tests/ui/components/Input.test.tsx
+++ b/tests/ui/components/Input.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Input } from '../../../src/ui/components/Input/Input.js';
+
+describe('Input', () => {
+  it('renders label and helper text', () => {
+    render(<Input label="Email" helperText="Enter email" />);
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Enter email')).toBeInTheDocument();
+  });
+
+  it('accepts typing', async () => {
+    const user = userEvent.setup();
+    render(<Input label="Name" />);
+    const input = screen.getByLabelText('Name');
+    await user.type(input, 'John');
+    expect((input as HTMLInputElement).value).toBe('John');
+  });
+
+  it('shows error state styling', () => {
+    render(<Input label="Password" error="Required" />);
+    const input = screen.getByLabelText('Password');
+    expect(input.className).toContain('border-danger');
+    expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+
+  it('renders icon', () => {
+    render(<Input label="Search" icon={<span data-testid="icon">i</span>} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('generates id and associates label', () => {
+    render(<Input label="Test" />);
+    const input = screen.getByLabelText('Test');
+    const label = screen.getByText('Test');
+    expect(input.id).toMatch(/^input-/);
+    expect(label).toHaveAttribute('for', input.id);
+  });
+
+  it('focuses input when label clicked', async () => {
+    const user = userEvent.setup();
+    render(<Input label="Username" />);
+    const label = screen.getByText('Username');
+    const input = screen.getByLabelText('Username');
+    await user.click(label);
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/tests/ui/components/Sidebar.test.tsx
+++ b/tests/ui/components/Sidebar.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+import userEvent from '@testing-library/user-event';
+import { Sidebar, SidebarItem } from '../../../src/ui/components/Sidebar/Sidebar.js';
+
+describe('Sidebar and SidebarItem', () => {
+  it('applies width classes', () => {
+    const { container } = render(<Sidebar width="lg" />);
+    const aside = container.firstElementChild as HTMLElement;
+    expect(aside.className).toContain('w-80');
+  });
+
+  it('handles item click callbacks', async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+    const { container } = render(
+      <Sidebar>
+        <SidebarItem onClick={onClick}>Item</SidebarItem>
+      </Sidebar>
+    );
+    const item = container.querySelector('div div') as HTMLElement;
+    await user.click(item);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('shows active state and icon', () => {
+    const { container } = render(
+      <Sidebar>
+        <SidebarItem active icon={<span data-testid="icon" />}>Item</SidebarItem>
+      </Sidebar>
+    );
+    const itemDiv = container.querySelector('div div') as HTMLElement;
+    expect(itemDiv).toHaveClass('bg-action');
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+});

--- a/tests/ui/components/ToggleSwitch.test.tsx
+++ b/tests/ui/components/ToggleSwitch.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { jest } from '@jest/globals';
+import userEvent from '@testing-library/user-event';
+import { ToggleSwitch } from '../../../src/ui/components/ToggleSwitch/ToggleSwitch.js';
+
+describe('ToggleSwitch', () => {
+  it('toggles checked state on click and calls onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<ToggleSwitch checked={false} onChange={onChange} aria-label="toggle" />);
+    await user.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('supports keyboard activation', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<ToggleSwitch checked={false} onChange={onChange} aria-label="toggle" />);
+    const toggle = screen.getByRole('switch');
+    toggle.focus();
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('does nothing when disabled', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<ToggleSwitch checked={false} onChange={onChange} disabled aria-label="toggle" />);
+    const toggle = screen.getByRole('switch');
+    await user.click(toggle);
+    await user.keyboard('{Space}');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- mock CSS modules with a Proxy so class names are readable in tests
- test Card component rendering, elevation and class merging
- test Grid column counts, gap sizes and custom classes
- test Sidebar width, item clicks and active state
- update the testing checklist for new coverage
- add interactive Card click support and tests

## Testing
- `node --experimental-vm-modules ./node_modules/.bin/jest tests/ui/components/Badge.test.tsx tests/ui/components/ToggleSwitch.test.tsx tests/ui/components/Input.test.tsx tests/ui/components/Button.test.tsx tests/ui/components/Card.test.tsx tests/ui/components/Grid.test.tsx tests/ui/components/Sidebar.test.tsx`
- `npm test` *(fails: PluginManifestSchema and other suites)*

------
https://chatgpt.com/codex/tasks/task_e_686b0cba1d4c8322bd45a48696cda58d