### PR TITLE
Add sidebar expand test and plugin schema validation

### DIFF
--- a/TESTING_IMPLEMENTATION_CHECKLIST.md
+++ b/TESTING_IMPLEMENTATION_CHECKLIST.md
@@ -126,7 +126,7 @@ This section covers tasks from `docs/testing/UI_COMPONENT_TEST_PLAN.md`.
   - [X] Responsive className passthrough.
 
 - [ ] **Implement `Sidebar` & `SidebarItem` Tests (`tests/ui/components/Sidebar.test.tsx`, `SidebarItem.test.tsx`):**
-  - [ ] Collapse/expand behaviour.
+  - [X] Collapse/expand behaviour.
   - [X] Item click callbacks.
   - [X] Active item highlighting.
   - [X] Icon rendering.
@@ -166,7 +166,7 @@ This section covers tasks from `docs/testing/UI_COMPONENT_TEST_PLAN.md`.
   - [ ] Displays success feedback.
 
 - [X] **Implement `PluginSettings` Tests (`tests/ui/components/PluginSettings.test.tsx`):**
-  - [ ] Loads plugin schema.
+  - [X] Loads plugin schema.
   - [X] Enable/disable actions.
   - [ ] Configuration validation.
 

--- a/tests/ui/components/PluginSettings.test.tsx
+++ b/tests/ui/components/PluginSettings.test.tsx
@@ -3,6 +3,17 @@ import userEvent from '@testing-library/user-event';
 import { PluginSettings } from '../../../src/ui/components/PluginSettings/PluginSettings.js';
 import { PluginStatus } from '../../../src/core/enhanced-plugin-manager.js';
 import { jest } from '@jest/globals';
+import { z } from 'zod';
+
+jest.mock('../../../src/ui/node-module-loader.js', () => ({
+  loadNodeModule: async () => ({ z })
+}));
+
+jest.mock('../../../src/lib/schemas/plugins/script-runner.js', () => ({
+  createScriptRunnerSchemas: async () => ({
+    scriptRunnerConfigSchema: z.object({ foo: z.string().min(2) })
+  })
+}));
 
 describe('PluginSettings', () => {
   const plugin = {
@@ -44,5 +55,46 @@ describe('PluginSettings', () => {
     await user.click(toggle);
     await waitFor(() => expect(settingsManager.savePluginRegistry).toHaveBeenCalled());
     expect(pluginManager.unloadPlugin).toHaveBeenCalledWith('test');
+  });
+
+  it('loads plugin schema and validates configuration', async () => {
+    const user = userEvent.setup();
+    const plugin = {
+      manifest: {
+        id: 'script-runner',
+        name: 'Script Runner',
+        description: 'desc',
+        version: '1.0.0',
+        type: 'configured',
+        permissions: []
+      },
+      status: PluginStatus.ACTIVE,
+      loadedAt: Date.now()
+    };
+    const pluginManager2 = {
+      getLoadedPlugins: jest.fn(() => [plugin]),
+      unloadPlugin: jest.fn()
+    } as any;
+
+    const settingsManager2 = {
+      loadPluginRegistry: jest.fn(async () => ({ plugins: { 'script-runner': { id: 'script-runner', enabled: true, configPath: '' } } })),
+      savePluginRegistry: jest.fn(async () => {}),
+      loadPluginConfig: jest.fn(async () => ({})),
+      savePluginConfig: jest.fn(async () => {})
+    } as any;
+
+    render(
+      <PluginSettings
+        settingsManager={settingsManager2}
+        pluginManager={pluginManager2}
+        targetPluginId="script-runner"
+      />
+    );
+
+    const input = await screen.findByLabelText('Foo');
+    await user.type(input, 'a');
+    await user.click(screen.getByRole('button', { name: 'Save Plugin Settings' }));
+    expect(await screen.findByText(/least 2/)).toBeInTheDocument();
+    expect(settingsManager2.savePluginConfig).not.toHaveBeenCalled();
   });
 });

--- a/tests/ui/components/Sidebar.test.tsx
+++ b/tests/ui/components/Sidebar.test.tsx
@@ -16,6 +16,14 @@ describe('Sidebar and SidebarItem', () => {
     expect(aside.className).toContain('w-48');
   });
 
+  it('expands from collapsed state when width changes', () => {
+    const { container, rerender } = render(<Sidebar width="sm" />);
+    const aside = container.firstElementChild as HTMLElement;
+    expect(aside.className).toContain('w-48');
+    rerender(<Sidebar width="lg" />);
+    expect(aside.className).toContain('w-80');
+  });
+
   it('handles item click callbacks', async () => {
     const user = userEvent.setup();
     const onClick = jest.fn();


### PR DESCRIPTION
## Summary
- expand sidebar width through rerender to test collapse/expand behaviour
- ensure PluginSettings loads schema and validates configuration
- check off related items in `TESTING_IMPLEMENTATION_CHECKLIST`

## Testing
- `npx jest tests/ui/components/Sidebar.test.tsx tests/ui/components/PluginSettings.test.tsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_686d10953e548322be983e4051971548